### PR TITLE
Add support for retrieving project process and work item field configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mcp-azure-devops"
 description = "A Model Context Protocol (MCP) server for Azure DevOps"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     {name = "Atle H. Havsø", email = "atle@havso.net"},
 ]

--- a/src/mcp_azure_devops/features/work_items/formatting.py
+++ b/src/mcp_azure_devops/features/work_items/formatting.py
@@ -21,11 +21,13 @@ def _format_field_value(field_value) -> str:
     elif isinstance(field_value, dict):
         # Handle dictionary fields like people references
         if 'displayName' in field_value:
-            return f"{field_value.get('displayName')} ({field_value.get('uniqueName', '')})"
+            return (f"{field_value.get('displayName')} "
+                  f"({field_value.get('uniqueName', '')})")
         else:
             # For other dictionaries, format as key-value pairs
             return ", ".join([f"{k}: {v}" for k, v in field_value.items()])
-    elif hasattr(field_value, 'display_name') and hasattr(field_value, 'unique_name'):
+    elif (hasattr(field_value, 'display_name') and 
+          hasattr(field_value, 'unique_name')):
         # Handle objects with display_name and unique_name
         return f"{field_value.display_name} ({field_value.unique_name})"
     elif hasattr(field_value, 'display_name'):

--- a/src/mcp_azure_devops/features/work_items/formatting.py
+++ b/src/mcp_azure_devops/features/work_items/formatting.py
@@ -6,348 +6,34 @@ This module provides functions to format work items for display.
 from azure.devops.v7_1.work_item_tracking.models import WorkItem
 
 
-def _format_header(work_item: WorkItem, fields: dict) -> list[str]:
+def _format_field_value(field_value) -> str:
     """
-    Format the header section of a work item.
+    Format a field value based on its type.
     
     Args:
-        work_item: The work item object
-        fields: Dictionary of work item fields
+        field_value: The value to format
         
     Returns:
-        List of strings with header information
+        Formatted string representation of the value
     """
-    title = fields.get("System.Title", "Untitled")
-    item_type = fields.get("System.WorkItemType", "Unknown")
-    state = fields.get("System.State", "Unknown")
-    project = fields.get("System.TeamProject", "Unknown")
-    
-    header = [f"# Work Item {work_item.id}: {title}",
-              f"Type: {item_type}",
-              f"State: {state}"]
-    
-    # Add revision number
-    if hasattr(work_item, 'rev'):
-        header.append(f"Revision: {work_item.rev}")
-    
-    header.append(f"Project: {project}")
-    
-    # Add link to the work item (if available)
-    try:
-        if hasattr(work_item, '_links') and work_item._links:
-            if (hasattr(work_item._links, 'html') and 
-                    hasattr(work_item._links.html, 'href')):
-                header.append(f"Web URL: {work_item._links.html.href}")
-    except Exception:
-        # If any error occurs, just skip adding the URL
-        pass
-    
-    return header
-
-
-def _format_description_sections(fields: dict) -> list[str]:
-    """
-    Format the description-related sections.
-    
-    Args:
-        fields: Dictionary of work item fields
-        
-    Returns:
-        List of strings with description sections
-    """
-    sections = []
-    
-    # Add description
-    if "System.Description" in fields:
-        sections.append("\n## Description")
-        sections.append(fields["System.Description"])
-    
-    # Add acceptance criteria if available
-    if "Microsoft.VSTS.Common.AcceptanceCriteria" in fields:
-        sections.append("\n## Acceptance Criteria")
-        sections.append(fields["Microsoft.VSTS.Common.AcceptanceCriteria"])
-    
-    # Add repro steps if available
-    if "Microsoft.VSTS.TCM.ReproSteps" in fields:
-        sections.append("\n## Repro Steps")
-        sections.append(fields["Microsoft.VSTS.TCM.ReproSteps"])
-    
-    # Add system info if available (for bugs)
-    if "Microsoft.VSTS.TCM.SystemInfo" in fields:
-        sections.append("\n## System Information")
-        sections.append(fields["Microsoft.VSTS.TCM.SystemInfo"])
-    
-    return sections
-
-
-def _format_people_info(fields: dict) -> list[str]:
-    """
-    Format information about people associated with the work item.
-    
-    Args:
-        fields: Dictionary of work item fields
-        
-    Returns:
-        List of strings with people information
-    """
-    people_info = []
-    
-    if "System.AssignedTo" in fields:
-        assigned_to = fields['System.AssignedTo']
-        # Handle the AssignedTo object which could be a dict or dict-like 
-        # object
-        if (hasattr(assigned_to, 'display_name') and 
-                hasattr(assigned_to, 'unique_name')):
-            # If it's an object with directly accessible properties
-            people_info.append(
-                f"Assigned To: {assigned_to.display_name} "
-                f"({assigned_to.unique_name})")
-        elif isinstance(assigned_to, dict):
-            # If it's a dictionary
-            display_name = assigned_to.get('displayName', '')
-            unique_name = assigned_to.get('uniqueName', '')
-            people_info.append(f"Assigned To: {display_name} ({unique_name})")
+    if field_value is None:
+        return "None"
+    elif isinstance(field_value, dict):
+        # Handle dictionary fields like people references
+        if 'displayName' in field_value:
+            return f"{field_value.get('displayName')} ({field_value.get('uniqueName', '')})"
         else:
-            # Fallback to display the raw value if we can't parse it
-            people_info.append(f"Assigned To: {assigned_to}")
-    
-    # Add created by information
-    if "System.CreatedBy" in fields:
-        created_by = fields['System.CreatedBy']
-        if hasattr(created_by, 'display_name'):
-            people_info.append(f"Created By: {created_by.display_name}")
-        elif isinstance(created_by, dict) and 'displayName' in created_by:
-            people_info.append(f"Created By: {created_by['displayName']}")
-        else:
-            people_info.append(f"Created By: {created_by}")
-    
-    # Add activated by information (if available)
-    if "Microsoft.VSTS.Common.ActivatedBy" in fields:
-        activated_by = fields['Microsoft.VSTS.Common.ActivatedBy']
-        if hasattr(activated_by, 'display_name'):
-            people_info.append(f"Activated By: {activated_by.display_name}")
-        elif isinstance(activated_by, dict) and 'displayName' in activated_by:
-            people_info.append(f"Activated By: {activated_by['displayName']}")
-        else:
-            people_info.append(f"Activated By: {activated_by}")
-    
-    # Add resolved by information (if available)
-    if "Microsoft.VSTS.Common.ResolvedBy" in fields:
-        resolved_by = fields['Microsoft.VSTS.Common.ResolvedBy']
-        if hasattr(resolved_by, 'display_name'):
-            people_info.append(f"Resolved By: {resolved_by.display_name}")
-        elif isinstance(resolved_by, dict) and 'displayName' in resolved_by:
-            people_info.append(f"Resolved By: {resolved_by['displayName']}")
-        else:
-            people_info.append(f"Resolved By: {resolved_by}")
-    
-    return people_info
-
-
-def _format_dates(fields: dict) -> list[str]:
-    """
-    Format date information for the work item.
-    
-    Args:
-        fields: Dictionary of work item fields
-        
-    Returns:
-        List of strings with date information
-    """
-    date_info = []
-    
-    # Add created date
-    if "System.CreatedDate" in fields:
-        date_info.append(f"Created Date: {fields['System.CreatedDate']}")
-    
-    # Add state change date (if available)
-    if "Microsoft.VSTS.Common.StateChangeDate" in fields:
-        date_info.append(
-            f"State Changed: "
-            f"{fields['Microsoft.VSTS.Common.StateChangeDate']}")
-    
-    # Add activated date (if available)
-    if "Microsoft.VSTS.Common.ActivatedDate" in fields:
-        date_info.append(
-            f"Activated Date: {fields['Microsoft.VSTS.Common.ActivatedDate']}")
-    
-    # Add resolved date (if available)
-    if "Microsoft.VSTS.Common.ResolvedDate" in fields:
-        date_info.append(
-            f"Resolved Date: {fields['Microsoft.VSTS.Common.ResolvedDate']}")
-    
-    # Add last updated information
-    if "System.ChangedDate" in fields:
-        changed_date = fields['System.ChangedDate']
-        
-        # Add the changed by information if available
-        if "System.ChangedBy" in fields:
-            changed_by = fields['System.ChangedBy']
-            if hasattr(changed_by, 'display_name'):
-                date_info.append(
-                    f"Last updated {changed_date} by "
-                    f"{changed_by.display_name}")
-            elif isinstance(changed_by, dict) and 'displayName' in changed_by:
-                date_info.append(
-                    f"Last updated {changed_date} by "
-                    f"{changed_by['displayName']}")
-            else:
-                date_info.append(
-                    f"Last updated {changed_date} by {changed_by}")
-        else:
-            date_info.append(f"Last updated: {changed_date}")
-    
-    return date_info
-
-
-def _format_categorization(fields: dict) -> list[str]:
-    """
-    Format categorization information for the work item.
-    
-    Args:
-        fields: Dictionary of work item fields
-        
-    Returns:
-        List of strings with categorization information
-    """
-    categorization = []
-    
-    if "System.IterationPath" in fields:
-        categorization.append(f"Iteration: {fields['System.IterationPath']}")
-    
-    if "System.AreaPath" in fields:
-        categorization.append(f"Area: {fields['System.AreaPath']}")
-    
-    # Add value area (if available)
-    if "Microsoft.VSTS.Common.ValueArea" in fields:
-        categorization.append(
-            f"Value Area: {fields['Microsoft.VSTS.Common.ValueArea']}")
-    
-    # Add risk (if available)
-    if "Microsoft.VSTS.Common.Risk" in fields:
-        categorization.append(f"Risk: {fields['Microsoft.VSTS.Common.Risk']}")
-    
-    # Add severity (if available)
-    if "Microsoft.VSTS.Common.Severity" in fields:
-        categorization.append(
-            f"Severity: {fields['Microsoft.VSTS.Common.Severity']}")
-    
-    # Add tags
-    if "System.Tags" in fields and fields["System.Tags"]:
-        categorization.append(f"Tags: {fields['System.Tags']}")
-    
-    return categorization
-
-
-def _format_metrics(fields: dict) -> list[str]:
-    """
-    Format metric information for the work item.
-    
-    Args:
-        fields: Dictionary of work item fields
-        
-    Returns:
-        List of strings with metric information
-    """
-    metrics = []
-    
-    # Add priority
-    if "Microsoft.VSTS.Common.Priority" in fields:
-        metrics.append(f"Priority: {fields['Microsoft.VSTS.Common.Priority']}")
-    
-    # Add effort/story points (could be in different fields depending on 
-    # process template)
-    if "Microsoft.VSTS.Scheduling.Effort" in fields:
-        metrics.append(f"Effort: {fields['Microsoft.VSTS.Scheduling.Effort']}")
-    if "Microsoft.VSTS.Scheduling.StoryPoints" in fields:
-        metrics.append(
-            f"Story Points: {fields['Microsoft.VSTS.Scheduling.StoryPoints']}")
-    
-    return metrics
-
-
-def _format_related_items(work_item: WorkItem) -> list[str]:
-    """
-    Format information about related work items using links.
-    
-    Args:
-        work_item: The work item object
-        
-    Returns:
-        List of strings with related work items information
-    """
-    related_items = []
-    
-    # Check if work item has links
-    if hasattr(work_item, 'relations') and work_item.relations:
-        # Check if there are work item links
-        links_section = []
-        
-        links_section.append("\n## Related Items")
-        for link in work_item.relations:
-            # Look for the related work items link collection
-            related_items.append(f"- {link.rel} URL: {link.url}")
-            if hasattr(link, 'attributes') and link.attributes:
-                related_items.append(f"  :: Attributes: {link.attributes}")
-    
-    
-    return related_items
-
-
-def _format_state_info(fields: dict) -> list[str]:
-    """
-    Format state-related information for the work item.
-    
-    Args:
-        fields: Dictionary of work item fields
-        
-    Returns:
-        List of strings with state information
-    """
-    state_info = []
-    
-    # Add reason (if available)
-    if "System.Reason" in fields:
-        state_info.append(f"Reason: {fields['System.Reason']}")
-    
-    return state_info
-
-
-def _format_scheduling_info(fields: dict) -> list[str]:
-    """
-    Format scheduling information for the work item.
-    
-    Args:
-        fields: Dictionary of work item fields
-        
-    Returns:
-        List of strings with scheduling information
-    """
-    scheduling_info = []
-    
-    # Add start date (if available)
-    if "Microsoft.VSTS.Scheduling.StartDate" in fields:
-        scheduling_info.append(
-            f"Start Date: {fields['Microsoft.VSTS.Scheduling.StartDate']}")
-    
-    # Add finish date (if available)
-    if "Microsoft.VSTS.Scheduling.FinishDate" in fields:
-        scheduling_info.append(
-            f"Finish Date: {fields['Microsoft.VSTS.Scheduling.FinishDate']}")
-    
-    # Add remaining work (if available)
-    if "Microsoft.VSTS.Scheduling.RemainingWork" in fields:
-        scheduling_info.append(
-            f"Remaining Work: "
-            f"{fields['Microsoft.VSTS.Scheduling.RemainingWork']} hours")
-    
-    # Add completed work (if available)
-    if "Microsoft.VSTS.Scheduling.CompletedWork" in fields:
-        scheduling_info.append(
-            f"Completed Work: "
-            f"{fields['Microsoft.VSTS.Scheduling.CompletedWork']} hours")
-    
-    return scheduling_info
+            # For other dictionaries, format as key-value pairs
+            return ", ".join([f"{k}: {v}" for k, v in field_value.items()])
+    elif hasattr(field_value, 'display_name') and hasattr(field_value, 'unique_name'):
+        # Handle objects with display_name and unique_name
+        return f"{field_value.display_name} ({field_value.unique_name})"
+    elif hasattr(field_value, 'display_name'):
+        # Handle objects with just display_name
+        return field_value.display_name
+    else:
+        # For everything else, use string representation
+        return str(field_value)
 
 
 def _format_board_info(fields: dict) -> list[str]:
@@ -412,23 +98,20 @@ def format_work_item(work_item: WorkItem) -> str:
         String with formatted work item details
     """
     fields = work_item.fields or {}
-    details = []
+    details = [f"# Work Item {work_item.id}"]
     
-    # Build the work item information in sections
-    details.extend(_format_header(work_item, fields))
-    details.extend(_format_description_sections(fields))
+    # List all fields alphabetically for consistent output
+    for field_name in sorted(fields.keys()):
+        field_value = fields[field_name]
+        formatted_value = _format_field_value(field_value)
+        details.append(f"- **{field_name}**: {formatted_value}")
     
-    # Add additional details section
-    details.append("\n## Additional Details")
-    
-    details.extend(_format_people_info(fields))
-    details.extend(_format_dates(fields))
-    details.extend(_format_state_info(fields))
-    details.extend(_format_board_info(fields))
-    details.extend(_format_scheduling_info(fields))
-    details.extend(_format_categorization(fields))
-    details.extend(_format_metrics(fields))
-    details.extend(_format_build_info(fields))
-    details.extend(_format_related_items(work_item))
+    # Add related items if available
+    if hasattr(work_item, 'relations') and work_item.relations:
+        details.append("\n## Related Items")
+        for link in work_item.relations:
+            details.append(f"- {link.rel} URL: {link.url}")
+            if hasattr(link, 'attributes') and link.attributes:
+                details.append(f"  :: Attributes: {link.attributes}")
     
     return "\n".join(details)

--- a/src/mcp_azure_devops/features/work_items/tools/__init__.py
+++ b/src/mcp_azure_devops/features/work_items/tools/__init__.py
@@ -4,6 +4,7 @@ Work item tools for Azure DevOps.
 from mcp_azure_devops.features.work_items.tools import (
     comments,
     create,
+    process,
     query,
     read,
     templates,
@@ -24,3 +25,4 @@ def register_tools(mcp) -> None:
     create.register_tools(mcp)
     types.register_tools(mcp)
     templates.register_tools(mcp)
+    process.register_tools(mcp)

--- a/src/mcp_azure_devops/features/work_items/tools/__init__.py
+++ b/src/mcp_azure_devops/features/work_items/tools/__init__.py
@@ -6,6 +6,7 @@ from mcp_azure_devops.features.work_items.tools import (
     create,
     query,
     read,
+    templates,
     types,
 )
 
@@ -22,3 +23,4 @@ def register_tools(mcp) -> None:
     comments.register_tools(mcp)
     create.register_tools(mcp)
     types.register_tools(mcp)
+    templates.register_tools(mcp)

--- a/src/mcp_azure_devops/features/work_items/tools/__init__.py
+++ b/src/mcp_azure_devops/features/work_items/tools/__init__.py
@@ -6,6 +6,7 @@ from mcp_azure_devops.features.work_items.tools import (
     create,
     query,
     read,
+    types,
 )
 
 
@@ -20,3 +21,4 @@ def register_tools(mcp) -> None:
     read.register_tools(mcp)
     comments.register_tools(mcp)
     create.register_tools(mcp)
+    types.register_tools(mcp)

--- a/src/mcp_azure_devops/features/work_items/tools/create.py
+++ b/src/mcp_azure_devops/features/work_items/tools/create.py
@@ -4,7 +4,7 @@ Create operations for Azure DevOps work items.
 This module provides MCP tools for creating work items.
 """
 import os
-from typing import Any, Dict, Optional, Union, List
+from typing import Any, Dict, Optional
 
 from azure.devops.v7_1.work_item_tracking import WorkItemTrackingClient
 from azure.devops.v7_1.work_item_tracking.models import JsonPatchOperation

--- a/src/mcp_azure_devops/features/work_items/tools/create.py
+++ b/src/mcp_azure_devops/features/work_items/tools/create.py
@@ -4,7 +4,7 @@ Create operations for Azure DevOps work items.
 This module provides MCP tools for creating work items.
 """
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union, List
 
 from azure.devops.v7_1.work_item_tracking import WorkItemTrackingClient
 from azure.devops.v7_1.work_item_tracking.models import JsonPatchOperation
@@ -203,8 +203,8 @@ def _add_link_to_work_item_impl(
     return format_work_item(updated_work_item)
 
 
-def _prepare_create_fields(
-    title: str,
+def _prepare_standard_fields(
+    title: Optional[str] = None,
     description: Optional[str] = None,
     state: Optional[str] = None,
     assigned_to: Optional[str] = None,
@@ -215,7 +215,7 @@ def _prepare_create_fields(
     tags: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
-    Prepare fields dictionary for work item creation.
+    Prepare fields dictionary with standard fields for work item creation/update.
     
     Args:
         title: The title of the work item
@@ -231,9 +231,10 @@ def _prepare_create_fields(
     Returns:
         Dictionary of field name/value pairs
     """
-    fields = {
-        "System.Title": title
-    }
+    fields = {}
+    
+    if title:
+        fields["System.Title"] = title
     
     if description:
         fields["System.Description"] = description
@@ -263,6 +264,44 @@ def _prepare_create_fields(
     return fields
 
 
+def _ensure_system_prefix(field_name: str) -> str:
+    """
+    Ensure field names have appropriate prefix.
+    
+    Args:
+        field_name: The field name to format
+        
+    Returns:
+        Formatted field name with prefix if needed
+    """
+    if field_name.startswith("System.") or field_name.startswith("Microsoft."):
+        return field_name
+    
+    # Check for commonly used short names
+    common_fields = {
+        "title": "System.Title",
+        "description": "System.Description",
+        "state": "System.State",
+        "assignedto": "System.AssignedTo",
+        "assigned": "System.AssignedTo",
+        "iterationpath": "System.IterationPath",
+        "iteration": "System.IterationPath",
+        "areapath": "System.AreaPath",
+        "area": "System.AreaPath",
+        "tags": "System.Tags",
+        "storypoints": "Microsoft.VSTS.Scheduling.StoryPoints",
+        "priority": "Microsoft.VSTS.Common.Priority"
+    }
+    
+    # Try to match common field names (case-insensitive)
+    normalized = field_name.lower().replace("_", "").replace(" ", "")
+    if normalized in common_fields:
+        return common_fields[normalized]
+    
+    # If not recognized, assume it's a custom field
+    return field_name
+
+
 def register_tools(mcp) -> None:
     """
     Register work item creation tools with the MCP server.
@@ -276,6 +315,7 @@ def register_tools(mcp) -> None:
         title: str,
         project: str,
         work_item_type: str,
+        fields: Optional[Dict[str, Any]] = None,
         description: Optional[str] = None,
         state: Optional[str] = None,
         assigned_to: Optional[str] = None,
@@ -304,6 +344,7 @@ def register_tools(mcp) -> None:
             project: The project name or ID where the work item will be created
             work_item_type: Type of work item (e.g., "User Story", "Bug", 
                 "Task")
+            fields: Optional dictionary of additional field name/value pairs to set
             description: Optional description of the work item
             state: Optional initial state for the work item
             assigned_to: Optional user email to assign the work item to
@@ -321,13 +362,24 @@ def register_tools(mcp) -> None:
         """
         try:
             wit_client = get_work_item_client()
-            fields = _prepare_create_fields(
+            
+            # Start with standard fields
+            all_fields = _prepare_standard_fields(
                 title, description, state, assigned_to,
                 iteration_path, area_path, story_points, priority, tags
             )
             
+            # Add custom fields if provided
+            if fields:
+                for field_name, field_value in fields.items():
+                    field_name = _ensure_system_prefix(field_name)
+                    all_fields[field_name] = field_value
+            
+            if not all_fields.get("System.Title"):
+                return "Error: Title is required for work item creation"
+            
             return _create_work_item_impl(
-                fields=fields,
+                fields=all_fields,
                 project=project,
                 work_item_type=work_item_type,
                 wit_client=wit_client,
@@ -343,6 +395,7 @@ def register_tools(mcp) -> None:
     @mcp.tool()
     def update_work_item(
         id: int,
+        fields: Optional[Dict[str, Any]] = None,
         project: Optional[str] = None,
         title: Optional[str] = None,
         description: Optional[str] = None,
@@ -363,6 +416,7 @@ def register_tools(mcp) -> None:
         - Update the description or details of a requirement
         - Modify effort estimates or priority levels
         - Add or change classification (area/iteration)
+        - Update any field supported by the work item type
         
         IMPORTANT: This tool updates the work item directly in Azure DevOps.
         Changes will be immediately visible to all users with access to the
@@ -371,6 +425,7 @@ def register_tools(mcp) -> None:
         
         Args:
             id: The ID of the work item to update
+            fields: Optional dictionary of field name/value pairs to update
             project: Optional project name or ID
             title: Optional new title for the work item
             description: Optional new description
@@ -388,21 +443,25 @@ def register_tools(mcp) -> None:
         """
         try:
             wit_client = get_work_item_client()
-            fields = _prepare_create_fields(
-                title if title else "", description, state, assigned_to,
+            
+            # Start with standard fields
+            all_fields = _prepare_standard_fields(
+                title, description, state, assigned_to,
                 iteration_path, area_path, story_points, priority, tags
             )
             
-            # Remove empty title if it was not provided
-            if not title:
-                fields.pop("System.Title", None)
+            # Add custom fields if provided
+            if fields:
+                for field_name, field_value in fields.items():
+                    field_name = _ensure_system_prefix(field_name)
+                    all_fields[field_name] = field_value
                 
-            if not fields:
+            if not all_fields:
                 return "Error: At least one field must be specified for update"
             
             return _update_work_item_impl(
                 id=id,
-                fields=fields,
+                fields=all_fields,
                 wit_client=wit_client,
                 project=project
             )

--- a/src/mcp_azure_devops/features/work_items/tools/create.py
+++ b/src/mcp_azure_devops/features/work_items/tools/create.py
@@ -215,7 +215,8 @@ def _prepare_standard_fields(
     tags: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
-    Prepare fields dictionary with standard fields for work item creation/update.
+    Prepare fields dictionary with standard fields for work item 
+    creation/update.
     
     Args:
         title: The title of the work item
@@ -344,7 +345,8 @@ def register_tools(mcp) -> None:
             project: The project name or ID where the work item will be created
             work_item_type: Type of work item (e.g., "User Story", "Bug", 
                 "Task")
-            fields: Optional dictionary of additional field name/value pairs to set
+            fields: Optional dictionary of additional field name/value pairs 
+                to set
             description: Optional description of the work item
             state: Optional initial state for the work item
             assigned_to: Optional user email to assign the work item to

--- a/src/mcp_azure_devops/features/work_items/tools/process.py
+++ b/src/mcp_azure_devops/features/work_items/tools/process.py
@@ -106,10 +106,13 @@ def _list_processes_impl() -> str:
         headers = ["Name", "ID", "Reference Name", "Description", "Is Default"]
         rows = []
         for process in processes:
-            is_default = "Yes" if getattr(process.properties, 'is_default', False) else "No"
+            is_default = ("Yes" if getattr(process.properties, 
+                                        'is_default', False) 
+                          else "No")
             row = (f"| {process.name} | {process.type_id} | " +
                    f"{getattr(process, 'reference_name', 'N/A')} | " +
-                   f"{getattr(process, 'description', 'N/A')} | {is_default} |")
+                   f"{getattr(process, 'description', 'N/A')} | " +
+                   f"{is_default} |")
             rows.append(row)
         
         result.append(_format_table(headers, rows))

--- a/src/mcp_azure_devops/features/work_items/tools/process.py
+++ b/src/mcp_azure_devops/features/work_items/tools/process.py
@@ -1,0 +1,186 @@
+"""
+Process operations for Azure DevOps.
+
+This module provides MCP tools for retrieving process information.
+"""
+from mcp_azure_devops.features.work_items.common import (
+    AzureDevOpsClientError,
+)
+from mcp_azure_devops.utils.azure_client import (
+    get_core_client,
+    get_work_item_tracking_process_client,
+)
+
+
+def _format_table(headers, rows):
+    """Format data as a markdown table."""
+    result = []
+    result.append("| " + " | ".join(headers) + " |")
+    result.append("| " + " | ".join(["----"] * len(headers)) + " |")
+    result.extend(rows)
+    return "\n".join(result)
+
+
+def _get_project_process_id_impl(project: str) -> str:
+    """Implementation of project process ID retrieval."""
+    try:
+        # Get project details with process information
+        core_client = get_core_client()
+        project_details = core_client.get_project(project, include_capabilities=True)
+        process_template = project_details.capabilities.get("processTemplate", {})
+        
+        process_id = process_template.get("templateTypeId")
+        process_name = process_template.get("templateName")
+        
+        if not process_id:
+            return f"Could not determine process ID for project {project}."
+        
+        result = [f"# Process for Project: {project_details.name}"]
+        result.append(f"**Process Name:** {process_name}")
+        result.append(f"**Process ID:** {process_id}")
+        
+        return "\n".join(result)
+    except Exception as e:
+        return f"Error retrieving process ID for project '{project}': {str(e)}"
+
+
+def _get_process_details_impl(process_id: str) -> str:
+    """Implementation of process details retrieval."""
+    try:
+        process_client = get_work_item_tracking_process_client()
+        process = process_client.get_process_by_its_id(process_id)
+        
+        if not process:
+            return f"Process with ID '{process_id}' not found."
+        
+        result = [f"# Process: {process.name}"]
+        
+        if hasattr(process, "description") and process.description:
+            result.append(f"\n**Description:** {process.description}")
+        
+        result.append(f"**Reference Name:** {getattr(process, 'reference_name', 'N/A')}")
+        result.append(f"**Type ID:** {getattr(process, 'type_id', 'N/A')}")
+        
+        # Get process properties like isDefault, isEnabled, etc.
+        properties = getattr(process, "properties", None)
+        if properties:
+            result.append("\n## Properties")
+            for attr in ["is_default", "is_enabled"]:
+                value = getattr(properties, attr, None)
+                if value is not None:
+                    attr_name = attr.replace("_", " ").capitalize()
+                    result.append(f"**{attr_name}:** {value}")
+        
+        # Get work item types for this process
+        wit_types = process_client.get_process_work_item_types(process_id)
+        if wit_types:
+            result.append("\n## Work Item Types")
+            
+            headers = ["Name", "Reference Name", "Description"]
+            rows = [
+                f"| {wit.name} | {getattr(wit, 'reference_name', 'N/A')} | " +
+                f"{getattr(wit, 'description', 'N/A')} |"
+                for wit in wit_types
+            ]
+            
+            result.append(_format_table(headers, rows))
+        
+        return "\n".join(result)
+    except Exception as e:
+        return f"Error retrieving process details for process ID '{process_id}': {str(e)}"
+
+
+def _list_processes_impl() -> str:
+    """Implementation of processes list retrieval."""
+    try:
+        process_client = get_work_item_tracking_process_client()
+        processes = process_client.get_list_of_processes()
+        
+        if not processes:
+            return "No processes found in the organization."
+        
+        result = ["# Available Processes"]
+        
+        headers = ["Name", "ID", "Reference Name", "Description", "Is Default"]
+        rows = [
+            f"| {process.name} | {process.type_id} | " +
+            f"{getattr(process, 'reference_name', 'N/A')} | " +
+            f"{getattr(process, 'description', 'N/A')} | " +
+            f"{'Yes' if getattr(process.properties, 'is_default', False) else 'No'} |"
+            for process in processes
+        ]
+        
+        result.append(_format_table(headers, rows))
+        return "\n".join(result)
+    except Exception as e:
+        return f"Error retrieving processes: {str(e)}"
+
+
+def register_tools(mcp) -> None:
+    """
+    Register process tools with the MCP server.
+    
+    Args:
+        mcp: The FastMCP server instance
+    """
+    
+    @mcp.tool()
+    def get_project_process_id(project: str) -> str:
+        """
+        Gets the process ID associated with a project.
+        
+        Use this tool when you need to:
+        - Find out which process a project is using
+        - Get the process ID for use in other process-related operations
+        - Verify process information for a project
+        
+        Args:
+            project: Project ID or project name
+            
+        Returns:
+            Formatted information about the process including name and ID
+        """
+        try:
+            return _get_project_process_id_impl(project)
+        except Exception as e:
+            return f"Error: {str(e)}"
+    
+    @mcp.tool()
+    def get_process_details(process_id: str) -> str:
+        """
+        Gets detailed information about a specific process.
+        
+        Use this tool when you need to:
+        - View process properties and configuration
+        - Get a list of work item types defined in a process
+        - Check if a process is the default for the organization
+        
+        Args:
+            process_id: The ID of the process
+            
+        Returns:
+            Detailed information about the process including properties and
+            available work item types
+        """
+        try:
+            return _get_process_details_impl(process_id)
+        except Exception as e:
+            return f"Error: {str(e)}"
+    
+    @mcp.tool()
+    def list_processes() -> str:
+        """
+        Lists all available processes in the organization.
+        
+        Use this tool when you need to:
+        - See what processes are available in your Azure DevOps organization
+        - Find process IDs for project creation or configuration
+        - Check which process is set as the default
+        
+        Returns:
+            A formatted table of all processes with names, IDs, and descriptions
+        """
+        try:
+            return _list_processes_impl()
+        except Exception as e:
+            return f"Error: {str(e)}"

--- a/src/mcp_azure_devops/features/work_items/tools/templates.py
+++ b/src/mcp_azure_devops/features/work_items/tools/templates.py
@@ -1,0 +1,162 @@
+"""
+Work item templates operations for Azure DevOps.
+
+This module provides MCP tools for retrieving work item templates.
+"""
+from typing import Optional
+from azure.devops.v7_1.work_item_tracking import WorkItemTrackingClient
+
+from mcp_azure_devops.features.work_items.common import (
+    AzureDevOpsClientError,
+    get_work_item_client,
+)
+
+
+def _format_table(headers, rows):
+    """Format data as a markdown table."""
+    result = []
+    result.append("| " + " | ".join(headers) + " |")
+    result.append("| " + " | ".join(["----"] * len(headers)) + " |")
+    result.extend(rows)
+    return "\n".join(result)
+
+
+def _format_work_item_template(template):
+    """Format work item template data for display."""
+    result = [f"# Template: {template.name}"]
+    
+    for attr in ["description", "work_item_type_name", "id"]:
+        value = getattr(template, attr, None)
+        if value:
+            result.append(f"**{attr.replace('_', ' ').capitalize()}:** {value}")
+    
+    fields = getattr(template, "fields", None)
+    if fields:
+        result.append("\n## Default Field Values")
+        for field, value in fields.items():
+            result.append(f"- **{field}**: {value}")
+    
+    return "\n".join(result)
+
+
+def _create_team_context(team_context_dict):
+    """Create a TeamContext object from a dictionary."""
+    from azure.devops.v7_1.work_item_tracking.models import TeamContext
+    return TeamContext(
+        project=team_context_dict.get('project'),
+        project_id=team_context_dict.get('project_id'),
+        team=team_context_dict.get('team'),
+        team_id=team_context_dict.get('team_id')
+    )
+
+
+def _get_work_item_templates_impl(team_context: dict, work_item_type: Optional[str],
+                                 wit_client: WorkItemTrackingClient) -> str:
+    """Implementation of work item templates retrieval."""
+    try:
+        team_ctx = _create_team_context(team_context)
+        templates = wit_client.get_templates(team_ctx, work_item_type)
+        
+        team_display = team_context.get('team') or team_context.get('team_id')
+        
+        if not templates:
+            scope = f"work item type '{work_item_type}' in " if work_item_type else ""
+            return f"No templates found for {scope}team {team_display}."
+        
+        # Create header
+        project_display = team_context.get('project') or team_context.get('project_id')
+        header = f"# Work Item Templates for Team: {team_display} (Project: {project_display})"
+        if work_item_type:
+            header += f" (Filtered by type: {work_item_type})"
+        
+        headers = ["Name", "Work Item Type", "Description"]
+        
+        # Use list comprehension for table rows
+        rows = [
+            f"| {template.name} | {getattr(template, 'work_item_type_name', 'N/A')} | " +
+            f"{getattr(template, 'description', 'N/A')} |"
+            for template in templates
+        ]
+        
+        return f"{header}\n\n" + _format_table(headers, rows)
+    except Exception as e:
+        return f"Error retrieving templates: {str(e)}"
+
+
+def _get_work_item_template_impl(team_context: dict, template_id: str,
+                                wit_client: WorkItemTrackingClient) -> str:
+    """Implementation of work item template detail retrieval."""
+    try:
+        team_ctx = _create_team_context(team_context)
+        template = wit_client.get_template(team_ctx, template_id)
+        
+        if not template:
+            return f"Template with ID '{template_id}' not found."
+        
+        return _format_work_item_template(template)
+    except Exception as e:
+        return f"Error retrieving template '{template_id}': {str(e)}"
+
+
+def register_tools(mcp) -> None:
+    """
+    Register work item templates tools with the MCP server.
+    
+    Args:
+        mcp: The FastMCP server instance
+    """
+    
+    @mcp.tool()
+    def get_work_item_templates(team_context: dict, work_item_type: Optional[str]) -> str:
+        """
+        Gets a list of all work item templates for a team.
+        
+        Use this tool when you need to:
+        - Find available templates for creating work items
+        - Get template IDs for use in other operations
+        - Filter templates by work item type
+        
+        Args:
+            team_context: Dictionary containing team information with keys:
+                project: Project name (Optional if project_id is provided)
+                project_id: Project ID (Optional if project is provided)
+                team: Team name (Optional if team_id is provided)
+                team_id: Team ID (Optional if team is provided)
+            work_item_type: Optional work item type name to filter templates
+            
+        Returns:
+            A formatted table of all templates with names, work item types,
+            and descriptions
+        """
+        try:
+            wit_client = get_work_item_client()
+            return _get_work_item_templates_impl(team_context, work_item_type, wit_client)
+        except AzureDevOpsClientError as e:
+            return f"Error: {str(e)}"
+    
+    @mcp.tool()
+    def get_work_item_template(team_context: dict, template_id: str) -> str:
+        """
+        Gets detailed information about a specific work item template.
+        
+        Use this tool when you need to:
+        - View default field values in a template
+        - Understand what a template pre-populates in a work item
+        - Get complete details about a template
+        
+        Args:
+            team_context: Dictionary containing team information with keys:
+                project: Project name (Optional if project_id is provided)
+                project_id: Project ID (Optional if project is provided)
+                team: Team name (Optional if team_id is provided)
+                team_id: Team ID (Optional if team is provided)
+            template_id: The ID of the template
+            
+        Returns:
+            Detailed information about the template including default field values
+        """
+        try:
+            wit_client = get_work_item_client()
+            return _get_work_item_template_impl(team_context, template_id, wit_client)
+        except AzureDevOpsClientError as e:
+            return f"Error: {str(e)}"

--- a/src/mcp_azure_devops/features/work_items/tools/templates.py
+++ b/src/mcp_azure_devops/features/work_items/tools/templates.py
@@ -4,6 +4,7 @@ Work item templates operations for Azure DevOps.
 This module provides MCP tools for retrieving work item templates.
 """
 from typing import Optional
+
 from azure.devops.v7_1.work_item_tracking import WorkItemTrackingClient
 
 from mcp_azure_devops.features.work_items.common import (
@@ -28,13 +29,13 @@ def _format_work_item_template(template):
     for attr in ["description", "work_item_type_name", "id"]:
         value = getattr(template, attr, None)
         if value:
-            result.append(f"**{attr.replace('_', ' ').capitalize()}:** {value}")
+            result.append(f"{attr.replace('_', ' ').capitalize()}: {value}")
     
     fields = getattr(template, "fields", None)
     if fields:
         result.append("\n## Default Field Values")
         for field, value in fields.items():
-            result.append(f"- **{field}**: {value}")
+            result.append(f"- {field}: {value}")
     
     return "\n".join(result)
 
@@ -50,8 +51,11 @@ def _create_team_context(team_context_dict):
     )
 
 
-def _get_work_item_templates_impl(team_context: dict, work_item_type: Optional[str],
-                                 wit_client: WorkItemTrackingClient) -> str:
+def _get_work_item_templates_impl(
+    team_context: dict, 
+    work_item_type: Optional[str],
+    wit_client: WorkItemTrackingClient
+) -> str:
     """Implementation of work item templates retrieval."""
     try:
         team_ctx = _create_team_context(team_context)
@@ -60,12 +64,15 @@ def _get_work_item_templates_impl(team_context: dict, work_item_type: Optional[s
         team_display = team_context.get('team') or team_context.get('team_id')
         
         if not templates:
-            scope = f"work item type '{work_item_type}' in " if work_item_type else ""
+            scope = (f"work item type '{work_item_type}' in " 
+                    if work_item_type else "")
             return f"No templates found for {scope}team {team_display}."
         
         # Create header
-        project_display = team_context.get('project') or team_context.get('project_id')
-        header = f"# Work Item Templates for Team: {team_display} (Project: {project_display})"
+        project_display = (team_context.get('project') or 
+                          team_context.get('project_id'))
+        header = (f"# Work Item Templates for Team: {team_display} "
+                 f"(Project: {project_display})")
         if work_item_type:
             header += f" (Filtered by type: {work_item_type})"
         
@@ -73,7 +80,8 @@ def _get_work_item_templates_impl(team_context: dict, work_item_type: Optional[s
         
         # Use list comprehension for table rows
         rows = [
-            f"| {template.name} | {getattr(template, 'work_item_type_name', 'N/A')} | " +
+            f"| {template.name} | " 
+            f"{getattr(template, 'work_item_type_name', 'N/A')} | " +
             f"{getattr(template, 'description', 'N/A')} |"
             for template in templates
         ]
@@ -107,7 +115,10 @@ def register_tools(mcp) -> None:
     """
     
     @mcp.tool()
-    def get_work_item_templates(team_context: dict, work_item_type: Optional[str]) -> str:
+    def get_work_item_templates(
+        team_context: dict, 
+        work_item_type: Optional[str]
+    ) -> str:
         """
         Gets a list of all work item templates for a team.
         
@@ -130,7 +141,8 @@ def register_tools(mcp) -> None:
         """
         try:
             wit_client = get_work_item_client()
-            return _get_work_item_templates_impl(team_context, work_item_type, wit_client)
+            return _get_work_item_templates_impl(
+                team_context, work_item_type, wit_client)
         except AzureDevOpsClientError as e:
             return f"Error: {str(e)}"
     
@@ -153,10 +165,12 @@ def register_tools(mcp) -> None:
             template_id: The ID of the template
             
         Returns:
-            Detailed information about the template including default field values
+            Detailed information about the template including default field 
+            values
         """
         try:
             wit_client = get_work_item_client()
-            return _get_work_item_template_impl(team_context, template_id, wit_client)
+            return _get_work_item_template_impl(
+                team_context, template_id, wit_client)
         except AzureDevOpsClientError as e:
             return f"Error: {str(e)}"

--- a/src/mcp_azure_devops/features/work_items/tools/types.py
+++ b/src/mcp_azure_devops/features/work_items/tools/types.py
@@ -109,15 +109,14 @@ def _get_work_item_type_fields_impl(project: str, type_name: str,
         if not fields:
             return f"No fields found for work item type '{type_name}' in project {project}."
         
-        headers = ["Name", "Reference Name", "Type", "Required", "Read Only", "Allowed Values"]
+        headers = ["Name", "Reference Name", "Type", "Required", "Read Only"]
         
         # Simple table formatting
         rows = [
             f"| {field.name} | {field.reference_name} | " +
             f"{getattr(field, 'type', 'N/A')} | " +
             f"{'Yes' if getattr(field, 'required', False) else 'No'} | " +
-            f"{'Yes' if getattr(field, 'read_only', False) else 'No'} | " +
-            f"{', '.join(str(v) for v in getattr(field, 'allowed_values', []) or [])} |"
+            f"{'Yes' if getattr(field, 'read_only', False) else 'No'} | "
             for field in fields
         ]
         

--- a/src/mcp_azure_devops/features/work_items/tools/types.py
+++ b/src/mcp_azure_devops/features/work_items/tools/types.py
@@ -1,0 +1,437 @@
+"""
+Work item types and metadata operations for Azure DevOps.
+
+This module provides MCP tools for retrieving work item types, templates, and fields.
+"""
+from typing import Optional
+
+from azure.devops.v7_1.work_item_tracking import WorkItemTrackingClient
+
+from mcp_azure_devops.features.work_items.common import (
+    AzureDevOpsClientError,
+    get_work_item_client,
+)
+
+
+def _format_work_item_type(wit):
+    """Format work item type data for display."""
+    result = [f"# Work Item Type: {wit.name}"]
+    
+    description = getattr(wit, "description", None)
+    if description:
+        result.append(f"\n**Description:** {description}")
+    
+    for attr in ["color", "icon", "reference_name"]:
+        value = getattr(wit, attr, None)
+        if value:
+            result.append(f"**{attr.capitalize()}:** {value}")
+    
+    is_disabled = getattr(wit, "is_disabled", None)
+    if is_disabled is not None:
+        result.append(f"**Is Disabled:** {is_disabled}")
+    
+    states = getattr(wit, "states", None)
+    if states:
+        result.append("\n## States")
+        for state in states:
+            state_info = f"- **{state.name}** (Category: {state.state_category}, Color: {state.color})"
+            order = getattr(state, "order", None)
+            if order is not None:
+                state_info += f", Order: {order}"
+            result.append(state_info)
+    
+    return "\n".join(result)
+
+
+def _format_work_item_field(field):
+    """Format work item field data for display."""
+    result = [f"# Field: {field.name}"]
+    
+    for attr in ["reference_name", "description"]:
+        value = getattr(field, attr, None)
+        if value:
+            result.append(f"**{attr.capitalize()}:** {value}")
+    
+    field_type = getattr(field, "type", None)
+    if field_type:
+        result.append(f"**Type:** {field_type}")
+    
+    for attr in ["read_only", "required"]:
+        value = getattr(field, attr, None)
+        if value is not None:
+            result.append(f"**{attr.capitalize()}:** {value}")
+    
+    allowed_values = getattr(field, "allowed_values", None)
+    if allowed_values:
+        result.append("\n## Allowed Values")
+        for value in allowed_values:
+            result.append(f"- {value}")
+    
+    return "\n".join(result)
+
+
+def _format_work_item_template(template):
+    """Format work item template data for display."""
+    result = [f"# Template: {template.name}"]
+    
+    for attr in ["description", "work_item_type_name", "id"]:
+        value = getattr(template, attr, None)
+        if value:
+            result.append(f"**{attr.replace('_', ' ').capitalize()}:** {value}")
+    
+    fields = getattr(template, "fields", None)
+    if fields:
+        result.append("\n## Default Field Values")
+        for field, value in fields.items():
+            result.append(f"- **{field}**: {value}")
+    
+    return "\n".join(result)
+
+
+def _get_work_item_types_impl(project: str, wit_client: WorkItemTrackingClient) -> str:
+    """
+    Implementation of work item types retrieval.
+    
+    Args:
+        project: Project name or ID
+        wit_client: Work item tracking client
+    
+    Returns:
+        Formatted string containing work item types information
+    """
+    work_item_types = wit_client.get_work_item_types(project)
+    
+    if not work_item_types:
+        return f"No work item types found in project {project}."
+    
+    # Format simple list overview first
+    result = [f"# Work Item Types in Project: {project}\n"]
+    result.append("| Name | Reference Name | Description |")
+    result.append("| ---- | -------------- | ----------- |")
+    
+    for wit in work_item_types:
+        description = getattr(wit, "description", "N/A")
+        ref_name = getattr(wit, "reference_name", "N/A")
+        result.append(f"| {wit.name} | {ref_name} | {description} |")
+    
+    return "\n".join(result)
+
+
+def _get_work_item_type_impl(project: str, type_name: str, 
+                             wit_client: WorkItemTrackingClient) -> str:
+    """
+    Implementation of work item type detail retrieval.
+    
+    Args:
+        project: Project name or ID
+        type_name: Work item type name
+        wit_client: Work item tracking client
+    
+    Returns:
+        Formatted string containing work item type details
+    """
+    work_item_type = wit_client.get_work_item_type(project, type_name)
+    
+    if not work_item_type:
+        return f"Work item type '{type_name}' not found in project {project}."
+    
+    return _format_work_item_type(work_item_type)
+
+
+def _get_work_item_type_fields_impl(project: str, type_name: str, 
+                                    wit_client: WorkItemTrackingClient) -> str:
+    """
+    Implementation of work item type fields retrieval.
+    
+    Args:
+        project: Project name or ID
+        type_name: Work item type name
+        wit_client: Work item tracking client
+    
+    Returns:
+        Formatted string containing work item type fields
+    """
+    try:
+        fields = wit_client.get_work_item_type_fields_with_references(project, type_name, expand="all")
+        
+        if not fields:
+            return f"No fields found for work item type '{type_name}' in project {project}."
+        
+        # Format simple list overview first
+        result = [f"# Fields for Work Item Type: {type_name}\n"]
+        result.append("| Name | Reference Name | Type | Required | Read Only |")
+        result.append("| ---- | -------------- | ---- | -------- | --------- |")
+        
+        for field in fields:
+            required = "Yes" if getattr(field, "always_required", False) else "No"
+            read_only = "Yes" if getattr(field, "read_only", False) else "No"
+            field_type = getattr(field, "type", "N/A")
+            result.append(f"| {field.name} | {field.reference_name} | {field_type} | {required} | {read_only} |")
+        
+        return "\n".join(result)
+    except Exception as e:
+        return f"Error retrieving fields for work item type '{type_name}' in project '{project}': {str(e)}"
+
+
+def _get_work_item_type_field_impl(project: str, type_name: str, field_name: str,
+                                   wit_client: WorkItemTrackingClient) -> str:
+    """
+    Implementation of work item type field detail retrieval.
+    
+    Args:
+        project: Project name or ID
+        type_name: Work item type name
+        field_name: Field reference name or display name
+        wit_client: Work item tracking client
+    
+    Returns:
+        Formatted string containing work item type field details
+    """
+    try:
+        field = wit_client.get_work_item_type_field_with_references(
+            project, type_name, field_name, expand="all")
+        
+        if not field:
+            return f"Field '{field_name}' not found for work item type '{type_name}' in project '{project}'."
+        
+        return _format_work_item_field(field)
+    except Exception as e:
+        return f"Error retrieving field '{field_name}' for work item type '{type_name}' in project '{project}': {str(e)}"
+
+
+def _create_team_context(team_context_dict):
+    """Create a TeamContext object from a dictionary."""
+    from azure.devops.v7_1.work_item_tracking.models import TeamContext
+    return TeamContext(
+        project=team_context_dict.get('project'),
+        project_id=team_context_dict.get('project_id'),
+        team=team_context_dict.get('team'),
+        team_id=team_context_dict.get('team_id')
+    )
+
+
+def _get_work_item_templates_impl(team_context: dict, work_item_type: Optional[str] ,
+                                 wit_client: WorkItemTrackingClient) -> str:
+    """
+    Implementation of work item templates retrieval.
+    
+    Args:
+        team_context: Team context dictionary with project and team information
+        work_item_type: Optional work item type to filter templates
+        wit_client: Work item tracking client
+    
+    Returns:
+        Formatted string containing work item templates
+    """
+    try:
+        team_ctx = _create_team_context(team_context)
+        templates = wit_client.get_templates(team_ctx, work_item_type)
+        
+        if not templates:
+            filter_msg = f" for work item type '{work_item_type}'" if work_item_type else ""
+            return f"No templates found{filter_msg} in team {team_context.get('team') or team_context.get('team_id')}."
+        
+        # Format simple list overview first
+        project_display = team_context.get('project') or team_context.get('project_id')
+        team_display = team_context.get('team') or team_context.get('team_id')
+        result = [f"# Work Item Templates for Team: {team_display} (Project: {project_display})\n"]
+        
+        if work_item_type:
+            result[0] += f" (Filtered by type: {work_item_type})"
+        
+        result.append("| Name | Work Item Type | Description |")
+        result.append("| ---- | -------------- | ----------- |")
+        
+        for template in templates:
+            description = getattr(template, "description", "N/A")
+            wit_name = getattr(template, "work_item_type_name", "N/A")
+            result.append(f"| {template.name} | {wit_name} | {description} |")
+        
+        return "\n".join(result)
+    except Exception as e:
+        return f"Error retrieving templates: {str(e)}"
+
+
+def _get_work_item_template_impl(team_context: dict, template_id: str,
+                                wit_client: WorkItemTrackingClient) -> str:
+    """
+    Implementation of work item template detail retrieval.
+    
+    Args:
+        team_context: Team context dictionary with project and team information
+        template_id: Template ID
+        wit_client: Work item tracking client
+    
+    Returns:
+        Formatted string containing work item template details
+    """
+    try:
+        team_ctx = _create_team_context(team_context)
+        template = wit_client.get_template(team_ctx, template_id)
+        
+        if not template:
+            return f"Template with ID '{template_id}' not found."
+        
+        return _format_work_item_template(template)
+    except Exception as e:
+        return f"Error retrieving template '{template_id}': {str(e)}"
+
+
+def register_tools(mcp) -> None:
+    """
+    Register work item types and metadata tools with the MCP server.
+    
+    Args:
+        mcp: The FastMCP server instance
+    """
+    
+    @mcp.tool()
+    def get_work_item_types(project: str) -> str:
+        """
+        Gets a list of all work item types in a project.
+        
+        Use this tool when you need to:
+        - See what work item types are available in a project
+        - Get reference names for work item types to use in other operations
+        - Plan work item creation by understanding available types
+        
+        Args:
+            project: Project ID or project name
+            
+        Returns:
+            A formatted table of all work item types with names, reference names,
+            and descriptions
+        """
+        try:
+            wit_client = get_work_item_client()
+            return _get_work_item_types_impl(project, wit_client)
+        except AzureDevOpsClientError as e:
+            return f"Error: {str(e)}"
+    
+    @mcp.tool()
+    def get_work_item_type(project: str, type_name: str) -> str:
+        """
+        Gets detailed information about a specific work item type.
+        
+        Use this tool when you need to:
+        - Get complete details about a work item type
+        - Understand the states and transitions for a work item type
+        - Learn about the color and icon for a work item type
+        
+        Args:
+            project: Project ID or project name
+            type_name: The name of the work item type
+            
+        Returns:
+            Detailed information about the work item type including states,
+            color, icon, and reference name
+        """
+        try:
+            wit_client = get_work_item_client()
+            return _get_work_item_type_impl(project, type_name, wit_client)
+        except AzureDevOpsClientError as e:
+            return f"Error: {str(e)}"
+    
+    @mcp.tool()
+    def get_work_item_type_fields(project: str, type_name: str) -> str:
+        """
+        Gets a list of all fields for a specific work item type.
+        
+        Use this tool when you need to:
+        - See what fields are available for a work item type
+        - Find required fields for creating work items of a specific type
+        - Get reference names for fields to use in queries or updates
+        
+        Args:
+            project: Project ID or project name
+            type_name: The name of the work item type
+            
+        Returns:
+            A formatted table of all fields with names, reference names,
+            types, and required/read-only status
+        """
+        try:
+            wit_client = get_work_item_client()
+            return _get_work_item_type_fields_impl(project, type_name, wit_client)
+        except AzureDevOpsClientError as e:
+            return f"Error: {str(e)}"
+    
+    @mcp.tool()
+    def get_work_item_type_field(project: str, type_name: str, field_name: str) -> str:
+        """
+        Gets detailed information about a specific field in a work item type.
+        
+        Use this tool when you need to:
+        - Get complete details about a work item field
+        - Check allowed values for a field
+        - Verify if a field is required or read-only
+        
+        Args:
+            project: Project ID or project name
+            type_name: The name of the work item type
+            field_name: The reference name or display name of the field
+            
+        Returns:
+            Detailed information about the field including type, allowed values,
+            and constraints
+        """
+        try:
+            wit_client = get_work_item_client()
+            return _get_work_item_type_field_impl(project, type_name, field_name, wit_client)
+        except AzureDevOpsClientError as e:
+            return f"Error: {str(e)}"
+    
+    @mcp.tool()
+    def get_work_item_templates(team_context: dict, work_item_type: Optional[str]) -> str:
+        """
+        Gets a list of all work item templates for a team.
+        
+        Use this tool when you need to:
+        - Find available templates for creating work items
+        - Get template IDs for use in other operations
+        - Filter templates by work item type
+        
+        Args:
+            team_context: Dictionary containing team information with keys:
+                project: Project name (Optional if project_id is provided)
+                project_id: Project ID (Optional if project is provided)
+                team: Team name (Optional if team_id is provided)
+                team_id: Team ID (Optional if team is provided)
+            work_item_type: Optional work item type name to filter templates
+            
+        Returns:
+            A formatted table of all templates with names, work item types,
+            and descriptions
+        """
+        try:
+            wit_client = get_work_item_client()
+            return _get_work_item_templates_impl(team_context, work_item_type, wit_client)
+        except AzureDevOpsClientError as e:
+            return f"Error: {str(e)}"
+    
+    @mcp.tool()
+    def get_work_item_template(team_context: dict, template_id: str) -> str:
+        """
+        Gets detailed information about a specific work item template.
+        
+        Use this tool when you need to:
+        - View default field values in a template
+        - Understand what a template pre-populates in a work item
+        - Get complete details about a template
+        
+        Args:
+            team_context: Dictionary containing team information with keys:
+                project: Project name (Optional if project_id is provided)
+                project_id: Project ID (Optional if project is provided)
+                team: Team name (Optional if team_id is provided)
+                team_id: Team ID (Optional if team is provided)
+            template_id: The ID of the template
+            
+        Returns:
+            Detailed information about the template including default field values
+        """
+        try:
+            wit_client = get_work_item_client()
+            return _get_work_item_template_impl(team_context, template_id, wit_client)
+        except AzureDevOpsClientError as e:
+            return f"Error: {str(e)}"

--- a/src/mcp_azure_devops/features/work_items/tools/types.py
+++ b/src/mcp_azure_devops/features/work_items/tools/types.py
@@ -1,16 +1,23 @@
 """
-Work item types and metadata operations for Azure DevOps.
+Work item types and fields operations for Azure DevOps.
 
-This module provides MCP tools for retrieving work item types, templates, and fields.
+This module provides MCP tools for retrieving work item types and fields.
 """
-from typing import Optional
-
 from azure.devops.v7_1.work_item_tracking import WorkItemTrackingClient
 
 from mcp_azure_devops.features.work_items.common import (
     AzureDevOpsClientError,
     get_work_item_client,
 )
+
+
+def _format_table(headers, rows):
+    """Format data as a markdown table."""
+    result = []
+    result.append("| " + " | ".join(headers) + " |")
+    result.append("| " + " | ".join(["----"] * len(headers)) + " |")
+    result.extend(rows)
+    return "\n".join(result)
 
 
 def _format_work_item_type(wit):
@@ -34,7 +41,7 @@ def _format_work_item_type(wit):
     if states:
         result.append("\n## States")
         for state in states:
-            state_info = f"- **{state.name}** (Category: {state.state_category}, Color: {state.color})"
+            state_info = f"- **{state.name}** (Category: {state.category}, Color: {state.color})"
             order = getattr(state, "order", None)
             if order is not None:
                 state_info += f", Order: {order}"
@@ -70,66 +77,27 @@ def _format_work_item_field(field):
     return "\n".join(result)
 
 
-def _format_work_item_template(template):
-    """Format work item template data for display."""
-    result = [f"# Template: {template.name}"]
-    
-    for attr in ["description", "work_item_type_name", "id"]:
-        value = getattr(template, attr, None)
-        if value:
-            result.append(f"**{attr.replace('_', ' ').capitalize()}:** {value}")
-    
-    fields = getattr(template, "fields", None)
-    if fields:
-        result.append("\n## Default Field Values")
-        for field, value in fields.items():
-            result.append(f"- **{field}**: {value}")
-    
-    return "\n".join(result)
-
-
 def _get_work_item_types_impl(project: str, wit_client: WorkItemTrackingClient) -> str:
-    """
-    Implementation of work item types retrieval.
-    
-    Args:
-        project: Project name or ID
-        wit_client: Work item tracking client
-    
-    Returns:
-        Formatted string containing work item types information
-    """
+    """Implementation of work item types retrieval."""
     work_item_types = wit_client.get_work_item_types(project)
     
     if not work_item_types:
         return f"No work item types found in project {project}."
     
-    # Format simple list overview first
-    result = [f"# Work Item Types in Project: {project}\n"]
-    result.append("| Name | Reference Name | Description |")
-    result.append("| ---- | -------------- | ----------- |")
+    headers = ["Name", "Reference Name", "Description"]
     
-    for wit in work_item_types:
-        description = getattr(wit, "description", "N/A")
-        ref_name = getattr(wit, "reference_name", "N/A")
-        result.append(f"| {wit.name} | {ref_name} | {description} |")
+    # Use list comprehension for more concise table building
+    rows = [
+        f"| {wit.name} | {getattr(wit, 'reference_name', 'N/A')} | {getattr(wit, 'description', 'N/A')} |"
+        for wit in work_item_types
+    ]
     
-    return "\n".join(result)
+    return f"# Work Item Types in Project: {project}\n\n" + _format_table(headers, rows)
 
 
 def _get_work_item_type_impl(project: str, type_name: str, 
                              wit_client: WorkItemTrackingClient) -> str:
-    """
-    Implementation of work item type detail retrieval.
-    
-    Args:
-        project: Project name or ID
-        type_name: Work item type name
-        wit_client: Work item tracking client
-    
-    Returns:
-        Formatted string containing work item type details
-    """
+    """Implementation of work item type detail retrieval."""
     work_item_type = wit_client.get_work_item_type(project, type_name)
     
     if not work_item_type:
@@ -140,53 +108,35 @@ def _get_work_item_type_impl(project: str, type_name: str,
 
 def _get_work_item_type_fields_impl(project: str, type_name: str, 
                                     wit_client: WorkItemTrackingClient) -> str:
-    """
-    Implementation of work item type fields retrieval.
-    
-    Args:
-        project: Project name or ID
-        type_name: Work item type name
-        wit_client: Work item tracking client
-    
-    Returns:
-        Formatted string containing work item type fields
-    """
+    """Implementation of work item type fields retrieval."""
     try:
         fields = wit_client.get_work_item_type_fields_with_references(project, type_name, expand="all")
         
         if not fields:
             return f"No fields found for work item type '{type_name}' in project {project}."
         
-        # Format simple list overview first
-        result = [f"# Fields for Work Item Type: {type_name}\n"]
-        result.append("| Name | Reference Name | Type | Required | Read Only |")
-        result.append("| ---- | -------------- | ---- | -------- | --------- |")
+        headers = ["Name", "Reference Name", "Type", "Required", "Read Only", "Allowed Values", "Default Value", "Help Text"]
         
-        for field in fields:
-            required = "Yes" if getattr(field, "always_required", False) else "No"
-            read_only = "Yes" if getattr(field, "read_only", False) else "No"
-            field_type = getattr(field, "type", "N/A")
-            result.append(f"| {field.name} | {field.reference_name} | {field_type} | {required} | {read_only} |")
+        # Use list comprehension for table rows
+        rows = [
+            f"| {field.name} | {field.reference_name} | " +
+            f"{getattr(field, 'type', 'N/A')} | " +
+            f"{'Yes' if getattr(field, 'always_required', False) else 'No'} | " +
+            f"{'Yes' if getattr(field, 'read_only', False) else 'No'} |" +
+            f"{', '.join(getattr(field, 'allowed_values', []))} | " +
+            f"{getattr(field, 'default_value', 'N/A')} |" +
+            f"{getattr(field, 'help_text', 'N/A')} |"
+            for field in fields
+        ]
         
-        return "\n".join(result)
+        return f"# Fields for Work Item Type: {type_name}\n\n" + _format_table(headers, rows)
     except Exception as e:
         return f"Error retrieving fields for work item type '{type_name}' in project '{project}': {str(e)}"
 
 
 def _get_work_item_type_field_impl(project: str, type_name: str, field_name: str,
                                    wit_client: WorkItemTrackingClient) -> str:
-    """
-    Implementation of work item type field detail retrieval.
-    
-    Args:
-        project: Project name or ID
-        type_name: Work item type name
-        field_name: Field reference name or display name
-        wit_client: Work item tracking client
-    
-    Returns:
-        Formatted string containing work item type field details
-    """
+    """Implementation of work item type field detail retrieval."""
     try:
         field = wit_client.get_work_item_type_field_with_references(
             project, type_name, field_name, expand="all")
@@ -199,87 +149,9 @@ def _get_work_item_type_field_impl(project: str, type_name: str, field_name: str
         return f"Error retrieving field '{field_name}' for work item type '{type_name}' in project '{project}': {str(e)}"
 
 
-def _create_team_context(team_context_dict):
-    """Create a TeamContext object from a dictionary."""
-    from azure.devops.v7_1.work_item_tracking.models import TeamContext
-    return TeamContext(
-        project=team_context_dict.get('project'),
-        project_id=team_context_dict.get('project_id'),
-        team=team_context_dict.get('team'),
-        team_id=team_context_dict.get('team_id')
-    )
-
-
-def _get_work_item_templates_impl(team_context: dict, work_item_type: Optional[str] ,
-                                 wit_client: WorkItemTrackingClient) -> str:
-    """
-    Implementation of work item templates retrieval.
-    
-    Args:
-        team_context: Team context dictionary with project and team information
-        work_item_type: Optional work item type to filter templates
-        wit_client: Work item tracking client
-    
-    Returns:
-        Formatted string containing work item templates
-    """
-    try:
-        team_ctx = _create_team_context(team_context)
-        templates = wit_client.get_templates(team_ctx, work_item_type)
-        
-        if not templates:
-            filter_msg = f" for work item type '{work_item_type}'" if work_item_type else ""
-            return f"No templates found{filter_msg} in team {team_context.get('team') or team_context.get('team_id')}."
-        
-        # Format simple list overview first
-        project_display = team_context.get('project') or team_context.get('project_id')
-        team_display = team_context.get('team') or team_context.get('team_id')
-        result = [f"# Work Item Templates for Team: {team_display} (Project: {project_display})\n"]
-        
-        if work_item_type:
-            result[0] += f" (Filtered by type: {work_item_type})"
-        
-        result.append("| Name | Work Item Type | Description |")
-        result.append("| ---- | -------------- | ----------- |")
-        
-        for template in templates:
-            description = getattr(template, "description", "N/A")
-            wit_name = getattr(template, "work_item_type_name", "N/A")
-            result.append(f"| {template.name} | {wit_name} | {description} |")
-        
-        return "\n".join(result)
-    except Exception as e:
-        return f"Error retrieving templates: {str(e)}"
-
-
-def _get_work_item_template_impl(team_context: dict, template_id: str,
-                                wit_client: WorkItemTrackingClient) -> str:
-    """
-    Implementation of work item template detail retrieval.
-    
-    Args:
-        team_context: Team context dictionary with project and team information
-        template_id: Template ID
-        wit_client: Work item tracking client
-    
-    Returns:
-        Formatted string containing work item template details
-    """
-    try:
-        team_ctx = _create_team_context(team_context)
-        template = wit_client.get_template(team_ctx, template_id)
-        
-        if not template:
-            return f"Template with ID '{template_id}' not found."
-        
-        return _format_work_item_template(template)
-    except Exception as e:
-        return f"Error retrieving template '{template_id}': {str(e)}"
-
-
 def register_tools(mcp) -> None:
     """
-    Register work item types and metadata tools with the MCP server.
+    Register work item types and fields tools with the MCP server.
     
     Args:
         mcp: The FastMCP server instance
@@ -378,60 +250,5 @@ def register_tools(mcp) -> None:
         try:
             wit_client = get_work_item_client()
             return _get_work_item_type_field_impl(project, type_name, field_name, wit_client)
-        except AzureDevOpsClientError as e:
-            return f"Error: {str(e)}"
-    
-    @mcp.tool()
-    def get_work_item_templates(team_context: dict, work_item_type: Optional[str]) -> str:
-        """
-        Gets a list of all work item templates for a team.
-        
-        Use this tool when you need to:
-        - Find available templates for creating work items
-        - Get template IDs for use in other operations
-        - Filter templates by work item type
-        
-        Args:
-            team_context: Dictionary containing team information with keys:
-                project: Project name (Optional if project_id is provided)
-                project_id: Project ID (Optional if project is provided)
-                team: Team name (Optional if team_id is provided)
-                team_id: Team ID (Optional if team is provided)
-            work_item_type: Optional work item type name to filter templates
-            
-        Returns:
-            A formatted table of all templates with names, work item types,
-            and descriptions
-        """
-        try:
-            wit_client = get_work_item_client()
-            return _get_work_item_templates_impl(team_context, work_item_type, wit_client)
-        except AzureDevOpsClientError as e:
-            return f"Error: {str(e)}"
-    
-    @mcp.tool()
-    def get_work_item_template(team_context: dict, template_id: str) -> str:
-        """
-        Gets detailed information about a specific work item template.
-        
-        Use this tool when you need to:
-        - View default field values in a template
-        - Understand what a template pre-populates in a work item
-        - Get complete details about a template
-        
-        Args:
-            team_context: Dictionary containing team information with keys:
-                project: Project name (Optional if project_id is provided)
-                project_id: Project ID (Optional if project is provided)
-                team: Team name (Optional if team_id is provided)
-                team_id: Team ID (Optional if team is provided)
-            template_id: The ID of the template
-            
-        Returns:
-            Detailed information about the template including default field values
-        """
-        try:
-            wit_client = get_work_item_client()
-            return _get_work_item_template_impl(team_context, template_id, wit_client)
         except AzureDevOpsClientError as e:
             return f"Error: {str(e)}"

--- a/src/mcp_azure_devops/server.py
+++ b/src/mcp_azure_devops/server.py
@@ -8,12 +8,14 @@ import argparse
 from mcp.server.fastmcp import FastMCP
 
 from mcp_azure_devops.features import register_all
+from mcp_azure_devops.utils import register_all_prompts
 
 # Create a FastMCP server instance with a name
 mcp = FastMCP("Azure DevOps")
 
 # Register all features
 register_all(mcp)
+register_all_prompts(mcp)
 
 def main():
     """Entry point for the command-line script."""

--- a/src/mcp_azure_devops/utils/__init__.py
+++ b/src/mcp_azure_devops/utils/__init__.py
@@ -1,0 +1,13 @@
+from mcp_azure_devops.utils.conventions_promp import register_prompt
+
+
+def register_all_prompts(mcp):
+    """
+    Register prompts with the MCP server.
+    
+    Args:
+        mcp: The FastMCP server instance
+    """
+    # Register prompts here
+    register_prompt(mcp)
+    

--- a/src/mcp_azure_devops/utils/azure_client.py
+++ b/src/mcp_azure_devops/utils/azure_client.py
@@ -7,6 +7,8 @@ import os
 from typing import Optional, Tuple
 
 from azure.devops.connection import Connection
+from azure.devops.v7_1.core import CoreClient
+from azure.devops.v7_1.work_item_tracking_process import WorkItemTrackingProcessClient
 from msrest.authentication import BasicAuthentication
 
 
@@ -36,3 +38,53 @@ def get_connection() -> Optional[Connection]:
     
     credentials = BasicAuthentication('', pat)
     return Connection(base_url=organization_url, creds=credentials)
+
+
+def get_core_client() -> CoreClient:
+    """
+    Get the Core client for Azure DevOps.
+    
+    Returns:
+        CoreClient instance
+        
+    Raises:
+        Exception: If the client cannot be created
+    """
+    connection = get_connection()
+    
+    if not connection:
+        raise Exception(
+            "Azure DevOps PAT or organization URL not found in environment variables."
+        )
+    
+    core_client = connection.clients.get_core_client()
+    
+    if not core_client:
+        raise Exception("Failed to get Core client.")
+    
+    return core_client
+
+
+def get_work_item_tracking_process_client() -> WorkItemTrackingProcessClient:
+    """
+    Get the Work Item Tracking Process client for Azure DevOps.
+    
+    Returns:
+        WorkItemTrackingProcessClient instance
+        
+    Raises:
+        Exception: If the client cannot be created
+    """
+    connection = get_connection()
+    
+    if not connection:
+        raise Exception(
+            "Azure DevOps PAT or organization URL not found in environment variables."
+        )
+    
+    process_client = connection.clients.get_work_item_tracking_process_client()
+    
+    if not process_client:
+        raise Exception("Failed to get Work Item Tracking Process client.")
+    
+    return process_client

--- a/src/mcp_azure_devops/utils/azure_client.py
+++ b/src/mcp_azure_devops/utils/azure_client.py
@@ -56,7 +56,8 @@ def get_core_client() -> CoreClient:
     
     if not connection:
         raise Exception(
-            "Azure DevOps PAT or organization URL not found in environment variables."
+            "Azure DevOps PAT or organization URL not found in "
+            "environment variables."
         )
     
     core_client = connection.clients.get_core_client()
@@ -81,7 +82,8 @@ def get_work_item_tracking_process_client() -> WorkItemTrackingProcessClient:
     
     if not connection:
         raise Exception(
-            "Azure DevOps PAT or organization URL not found in environment variables."
+            "Azure DevOps PAT or organization URL not found in "
+            "environment variables."
         )
     
     process_client = connection.clients.get_work_item_tracking_process_client()

--- a/src/mcp_azure_devops/utils/azure_client.py
+++ b/src/mcp_azure_devops/utils/azure_client.py
@@ -8,7 +8,9 @@ from typing import Optional, Tuple
 
 from azure.devops.connection import Connection
 from azure.devops.v7_1.core import CoreClient
-from azure.devops.v7_1.work_item_tracking_process import WorkItemTrackingProcessClient
+from azure.devops.v7_1.work_item_tracking_process import (
+    WorkItemTrackingProcessClient,
+)
 from msrest.authentication import BasicAuthentication
 
 

--- a/src/mcp_azure_devops/utils/conventions_promp.py
+++ b/src/mcp_azure_devops/utils/conventions_promp.py
@@ -1,0 +1,59 @@
+from mcp.server.fastmcp import FastMCP
+
+
+def register_prompt(mcp: FastMCP) -> None:
+    
+    @mcp.prompt(name="Create Conventions File", 
+                description="Create a starting conventions file Azure DevOps")
+    def create_conventions_file() -> str:
+        """
+        Create a starting conventions file for Azure DevOps.
+        
+        Use this prompt when you need to:
+        - Generate a conventions file for Azure DevOps
+        - Get a template for project conventions
+        - Start defining project standards and guidelines
+        
+        Returns:
+            A formatted conventions file template
+        """
+        
+        
+        return """Create a concise Azure DevOps conventions file to 
+    serve as a quick reference for our environment. 
+    This should capture all important patterns and structures 
+    while remaining compact enough for an LLM context.
+
+Using the available Azure DevOps tools, please:
+
+1. Get an overview of ALL projects (get_projects)
+2. For ALL projects:
+   - Identify teams (get_all_teams)
+   - Get area paths and iterations for each team 
+   (get_team_area_paths, get_team_iterations)
+3. Capture work item configuration for EACH project:
+   - Process ID and details (get_project_process_id, get_process_details)
+   - Work item types (get_work_item_types)
+   - For each work item type, get ALL fields 
+   (get_work_item_type_fields) and clearly identify mandatory fields
+   - Note differences in processes between projects
+
+Create a concise markdown document with these sections:
+
+1. **Projects and Teams**: 
+    List of all projects and their teams
+2. **Work Item Types by Process**: 
+    Work item types grouped by process template, 
+    including ALL fields for each type with mandatory fields clearly marked
+3. **Classification Structure**: 
+    Area paths and iterations for each team, 
+    with team-specific structures and patterns
+4. **Naming Conventions**: 
+    Observed naming patterns across projects, teams, and items
+
+Focus on identifying and documenting patterns and 
+variations between projects. 
+When listing field names or other details, prioritize the most important ones.
+The goal is to create a reference that captures key conventions 
+while staying concise."""
+    

--- a/tests/features/work_items/test_create.py
+++ b/tests/features/work_items/test_create.py
@@ -1,0 +1,320 @@
+from unittest.mock import MagicMock, patch
+
+from azure.devops.v7_1.work_item_tracking.models import WorkItem
+
+from mcp_azure_devops.features.work_items.tools.create import (
+    _add_link_to_work_item_impl,
+    _build_field_document,
+    _build_link_document,
+    _create_work_item_impl,
+    _ensure_system_prefix,
+    _get_organization_url,
+    _prepare_standard_fields,
+    _update_work_item_impl,
+)
+
+
+def test_build_field_document():
+    """Test building JSON patch document from fields dictionary."""
+    # Simple field values
+    fields = {
+        "System.Title": "Test Bug",
+        "System.Description": "This is a test bug",
+        "System.State": "Active",
+    }
+    
+    document = _build_field_document(fields)
+    
+    # Verify document structure
+    assert len(document) == 3
+    
+    # Check first operation
+    assert document[0].op == "add"
+    assert document[0].path == "/fields/System.Title"
+    assert document[0].value == "Test Bug"
+    
+    # Test with replace operation
+    document = _build_field_document(fields, "replace")
+    assert document[0].op == "replace"
+    
+    # Test with field name without /fields/ prefix
+    fields = {"Title": "Test Bug"}
+    document = _build_field_document(fields)
+    assert document[0].path == "/fields/Title"
+
+
+@patch("mcp_azure_devops.features.work_items.tools.create.os")
+def test_get_organization_url(mock_os):
+    """Test retrieving organization URL from environment."""
+    # Test with trailing slash
+    mock_os.environ.get.return_value = "https://dev.azure.com/org/"
+    url = _get_organization_url()
+    assert url == "https://dev.azure.com/org"
+    
+    # Test without trailing slash
+    mock_os.environ.get.return_value = "https://dev.azure.com/org"
+    url = _get_organization_url()
+    assert url == "https://dev.azure.com/org"
+    
+    # Test with empty value
+    mock_os.environ.get.return_value = ""
+    url = _get_organization_url()
+    assert url == ""
+
+
+def test_build_link_document():
+    """Test building link document for work item relationships."""
+    target_id = 123
+    link_type = "System.LinkTypes.Hierarchy-Reverse"
+    org_url = "https://dev.azure.com/org"
+    
+    document = _build_link_document(target_id, link_type, org_url)
+    
+    # Verify document structure
+    assert len(document) == 1
+    assert document[0].op == "add"
+    assert document[0].path == "/relations/-"
+    assert document[0].value["rel"] == link_type
+    assert document[0].value["url"] == "https://dev.azure.com/org/_apis/wit/workItems/123"
+
+
+def test_create_work_item_impl():
+    """Test creating a work item."""
+    # Arrange
+    mock_client = MagicMock()
+    
+    # Create mock for new work item
+    mock_work_item = MagicMock(spec=WorkItem)
+    mock_work_item.id = 123
+    mock_work_item.fields = {
+        "System.WorkItemType": "Bug",
+        "System.Title": "Test Bug",
+        "System.State": "New",
+        "System.TeamProject": "Test Project",
+    }
+    
+    mock_client.create_work_item.return_value = mock_work_item
+    
+    # Fields to create work item
+    fields = {
+        "System.Title": "Test Bug",
+        "System.Description": "This is a test bug",
+    }
+    
+    # Act
+    result = _create_work_item_impl(
+        fields=fields,
+        project="Test Project",
+        work_item_type="Bug",
+        wit_client=mock_client
+    )
+    
+    # Assert
+    mock_client.create_work_item.assert_called_once()
+    assert "Work Item 123: Test Bug" in result
+    assert "Type: Bug" in result
+    assert "State: New" in result
+    
+    # Verify document passed to create_work_item
+    args, kwargs = mock_client.create_work_item.call_args
+    document = kwargs.get("document") or args[0]
+    assert len(document) == 2  # Two fields in our test
+    assert kwargs.get("project") == "Test Project"
+    assert kwargs.get("type") == "Bug"
+
+
+@patch("mcp_azure_devops.features.work_items.tools.create._get_organization_url")
+def test_create_work_item_impl_with_parent(mock_get_org_url):
+    """Test creating a work item with parent relationship."""
+    # Arrange
+    mock_client = MagicMock()
+    
+    # Create mock for new work item
+    mock_work_item = MagicMock(spec=WorkItem)
+    mock_work_item.id = 123
+    mock_work_item.fields = {
+        "System.WorkItemType": "Bug",
+        "System.Title": "Test Bug",
+        "System.State": "New",
+        "System.TeamProject": "Test Project",
+    }
+    
+    # Setup organization URL
+    mock_get_org_url.return_value = "https://dev.azure.com/org"
+    
+    # Setup mock returns for create and update
+    mock_client.create_work_item.return_value = mock_work_item
+    mock_client.update_work_item.return_value = mock_work_item
+    
+    # Fields to create work item
+    fields = {
+        "System.Title": "Test Bug",
+        "System.Description": "This is a test bug",
+    }
+    
+    # Act
+    result = _create_work_item_impl(
+        fields=fields,
+        project="Test Project",
+        work_item_type="Bug",
+        wit_client=mock_client,
+        parent_id=456
+    )
+    
+    # Assert
+    mock_client.create_work_item.assert_called_once()
+    mock_client.update_work_item.assert_called_once()
+    
+    # Verify update_work_item was called with link document
+    args, kwargs = mock_client.update_work_item.call_args
+    document = kwargs.get("document") or args[0]
+    assert document[0].path == "/relations/-"
+    assert document[0].value["rel"] == "System.LinkTypes.Hierarchy-Reverse"
+    
+    # Check result formatting
+    assert "Work Item 123: Test Bug" in result
+
+
+def test_update_work_item_impl():
+    """Test updating a work item."""
+    # Arrange
+    mock_client = MagicMock()
+    
+    # Create mock for updated work item
+    mock_work_item = MagicMock(spec=WorkItem)
+    mock_work_item.id = 123
+    mock_work_item.fields = {
+        "System.WorkItemType": "Bug",
+        "System.Title": "Updated Bug",
+        "System.State": "Active",
+        "System.TeamProject": "Test Project",
+    }
+    
+    mock_client.update_work_item.return_value = mock_work_item
+    
+    # Fields to update
+    fields = {
+        "System.Title": "Updated Bug",
+        "System.State": "Active",
+    }
+    
+    # Act
+    result = _update_work_item_impl(
+        id=123,
+        fields=fields,
+        wit_client=mock_client,
+        project="Test Project"
+    )
+    
+    # Assert
+    mock_client.update_work_item.assert_called_once()
+    assert "Work Item 123: Updated Bug" in result
+    assert "Type: Bug" in result
+    assert "State: Active" in result
+    
+    # Verify document passed to update_work_item
+    args, kwargs = mock_client.update_work_item.call_args
+    document = kwargs.get("document") or args[0]
+    assert len(document) == 2  # Two fields in our test
+    assert all(op.op == "replace" for op in document)  # All operations should be replace
+    assert kwargs.get("id") == 123
+    assert kwargs.get("project") == "Test Project"
+
+
+def test_add_link_to_work_item_impl():
+    """Test adding a link between work items."""
+    # Arrange
+    mock_client = MagicMock()
+    
+    # Create mock for updated work item
+    mock_work_item = MagicMock(spec=WorkItem)
+    mock_work_item.id = 123
+    mock_work_item.fields = {
+        "System.WorkItemType": "Bug",
+        "System.Title": "Test Bug",
+        "System.State": "Active",
+        "System.TeamProject": "Test Project",
+    }
+    
+    mock_client.update_work_item.return_value = mock_work_item
+    
+    # Act with patch for organization URL
+    with patch("mcp_azure_devops.features.work_items.tools.create._get_organization_url",
+              return_value="https://dev.azure.com/org"):
+        result = _add_link_to_work_item_impl(
+            source_id=123,
+            target_id=456,
+            link_type="System.LinkTypes.Hierarchy-Reverse",
+            wit_client=mock_client,
+            project="Test Project"
+        )
+    
+    # Assert
+    mock_client.update_work_item.assert_called_once()
+    
+    # Verify document passed to update_work_item
+    args, kwargs = mock_client.update_work_item.call_args
+    document = kwargs.get("document") or args[0]
+    assert document[0].path == "/relations/-"
+    assert document[0].value["rel"] == "System.LinkTypes.Hierarchy-Reverse"
+    assert document[0].value["url"] == "https://dev.azure.com/org/_apis/wit/workItems/456"
+    
+    # Check result formatting
+    assert "Work Item 123: Test Bug" in result
+
+
+def test_prepare_standard_fields():
+    """Test preparing standard fields dictionary."""
+    # Test with all fields specified
+    fields = _prepare_standard_fields(
+        title="Test Bug",
+        description="This is a test bug",
+        state="Active",
+        assigned_to="user@example.com",
+        iteration_path="Project\\Sprint 1",
+        area_path="Project\\Area",
+        story_points=5.5,
+        priority=1,
+        tags="tag1; tag2"
+    )
+    
+    # Verify fields
+    assert fields["System.Title"] == "Test Bug"
+    assert fields["System.Description"] == "This is a test bug"
+    assert fields["System.State"] == "Active"
+    assert fields["System.AssignedTo"] == "user@example.com"
+    assert fields["System.IterationPath"] == "Project\\Sprint 1"
+    assert fields["System.AreaPath"] == "Project\\Area"
+    assert fields["Microsoft.VSTS.Scheduling.StoryPoints"] == "5.5"
+    assert fields["Microsoft.VSTS.Common.Priority"] == "1"
+    assert fields["System.Tags"] == "tag1; tag2"
+    
+    # Test with subset of fields
+    fields = _prepare_standard_fields(
+        title="Test Bug",
+        state="Active"
+    )
+    
+    assert len(fields) == 2
+    assert "System.Title" in fields
+    assert "System.State" in fields
+    assert "System.Description" not in fields
+
+
+def test_ensure_system_prefix():
+    """Test ensuring field names have proper prefix."""
+    # Test with already prefixed fields
+    assert _ensure_system_prefix("System.Title") == "System.Title"
+    assert _ensure_system_prefix("Microsoft.VSTS.Common.Priority") == "Microsoft.VSTS.Common.Priority"
+    
+    # Test with common short names
+    assert _ensure_system_prefix("title") == "System.Title"
+    assert _ensure_system_prefix("description") == "System.Description"
+    assert _ensure_system_prefix("assignedTo") == "System.AssignedTo"
+    assert _ensure_system_prefix("iterationPath") == "System.IterationPath"
+    assert _ensure_system_prefix("area_path") == "System.AreaPath"
+    assert _ensure_system_prefix("storyPoints") == "Microsoft.VSTS.Scheduling.StoryPoints"
+    assert _ensure_system_prefix("priority") == "Microsoft.VSTS.Common.Priority"
+    
+    # Test with unknown field - should return as is
+    assert _ensure_system_prefix("CustomField") == "CustomField"

--- a/tests/features/work_items/test_create.py
+++ b/tests/features/work_items/test_create.py
@@ -219,7 +219,8 @@ def test_update_work_item_impl():
     args, kwargs = mock_client.update_work_item.call_args
     document = kwargs.get("document") or args[0]
     assert len(document) == 2  # Two fields in our test
-    assert all(op.op == "replace" for op in document)  # All operations should be replace
+    # All operations should be replace
+    assert all(op.op == "replace" for op in document)
     assert kwargs.get("id") == 123
     assert kwargs.get("project") == "Test Project"
 
@@ -242,8 +243,9 @@ def test_add_link_to_work_item_impl():
     mock_client.update_work_item.return_value = mock_work_item
     
     # Act with patch for organization URL
-    with patch("mcp_azure_devops.features.work_items.tools.create._get_organization_url",
-              return_value="https://dev.azure.com/org"):
+    with patch(
+        "mcp_azure_devops.features.work_items.tools.create._get_organization_url",
+        return_value="https://dev.azure.com/org"):
         result = _add_link_to_work_item_impl(
             source_id=123,
             target_id=456,
@@ -310,7 +312,8 @@ def test_ensure_system_prefix():
     """Test ensuring field names have proper prefix."""
     # Test with already prefixed fields
     assert _ensure_system_prefix("System.Title") == "System.Title"
-    assert _ensure_system_prefix("Microsoft.VSTS.Common.Priority") == "Microsoft.VSTS.Common.Priority"
+    assert (_ensure_system_prefix("Microsoft.VSTS.Common.Priority") == 
+            "Microsoft.VSTS.Common.Priority")
     
     # Test with common short names
     assert _ensure_system_prefix("title") == "System.Title"
@@ -318,8 +321,10 @@ def test_ensure_system_prefix():
     assert _ensure_system_prefix("assignedTo") == "System.AssignedTo"
     assert _ensure_system_prefix("iterationPath") == "System.IterationPath"
     assert _ensure_system_prefix("area_path") == "System.AreaPath"
-    assert _ensure_system_prefix("storyPoints") == "Microsoft.VSTS.Scheduling.StoryPoints"
-    assert _ensure_system_prefix("priority") == "Microsoft.VSTS.Common.Priority"
+    assert (_ensure_system_prefix("storyPoints") == 
+            "Microsoft.VSTS.Scheduling.StoryPoints")
+    assert (_ensure_system_prefix("priority") == 
+            "Microsoft.VSTS.Common.Priority")
     
     # Test with unknown field - should return as is
     assert _ensure_system_prefix("CustomField") == "CustomField"

--- a/tests/features/work_items/test_create.py
+++ b/tests/features/work_items/test_create.py
@@ -111,9 +111,10 @@ def test_create_work_item_impl():
     
     # Assert
     mock_client.create_work_item.assert_called_once()
-    assert "Work Item 123: Test Bug" in result
-    assert "Type: Bug" in result
-    assert "State: New" in result
+    assert "# Work Item 123" in result
+    assert "**System.WorkItemType**: Bug" in result
+    assert "**System.Title**: Test Bug" in result
+    assert "**System.State**: New" in result
     
     # Verify document passed to create_work_item
     args, kwargs = mock_client.create_work_item.call_args
@@ -172,7 +173,8 @@ def test_create_work_item_impl_with_parent(mock_get_org_url):
     assert document[0].value["rel"] == "System.LinkTypes.Hierarchy-Reverse"
     
     # Check result formatting
-    assert "Work Item 123: Test Bug" in result
+    assert "# Work Item 123" in result
+    assert "**System.Title**: Test Bug" in result
 
 
 def test_update_work_item_impl():
@@ -208,9 +210,10 @@ def test_update_work_item_impl():
     
     # Assert
     mock_client.update_work_item.assert_called_once()
-    assert "Work Item 123: Updated Bug" in result
-    assert "Type: Bug" in result
-    assert "State: Active" in result
+    assert "# Work Item 123" in result
+    assert "**System.Title**: Updated Bug" in result
+    assert "**System.WorkItemType**: Bug" in result
+    assert "**System.State**: Active" in result
     
     # Verify document passed to update_work_item
     args, kwargs = mock_client.update_work_item.call_args
@@ -260,7 +263,9 @@ def test_add_link_to_work_item_impl():
     assert document[0].value["url"] == "https://dev.azure.com/org/_apis/wit/workItems/456"
     
     # Check result formatting
-    assert "Work Item 123: Test Bug" in result
+    assert "# Work Item 123" in result
+    assert "**System.Title**: Test Bug" in result
+    assert "**System.State**: Active" in result
 
 
 def test_prepare_standard_fields():

--- a/tests/features/work_items/test_process.py
+++ b/tests/features/work_items/test_process.py
@@ -30,7 +30,8 @@ def test_get_project_process_id_impl(mock_get_core_client):
     result = _get_project_process_id_impl("Test Project")
     
     # Assert
-    mock_core_client.get_project.assert_called_once_with("Test Project", include_capabilities=True)
+    mock_core_client.get_project.assert_called_once_with(
+        "Test Project", include_capabilities=True)
     
     # Check result formatting
     assert "Process for Project: Test Project" in result
@@ -75,7 +76,8 @@ def test_get_project_process_id_impl_error(mock_get_core_client):
     result = _get_project_process_id_impl("Test Project")
     
     # Assert
-    assert "Error retrieving process ID for project 'Test Project': Test error" in result
+    assert ("Error retrieving process ID for project 'Test Project': " 
+            "Test error" in result)
 
 
 @patch("mcp_azure_devops.features.work_items.tools.process.get_work_item_tracking_process_client")
@@ -110,7 +112,8 @@ def test_get_process_details_impl(mock_get_process_client):
     mock_wit_type2.description = "Represents a task item"
     
     mock_process_client.get_process_by_its_id.return_value = mock_process
-    mock_process_client.get_process_work_item_types.return_value = [mock_wit_type1, mock_wit_type2]
+    mock_process_client.get_process_work_item_types.return_value = [
+        mock_wit_type1, mock_wit_type2]
     
     # Act
     result = _get_process_details_impl("process-id-123")
@@ -165,13 +168,15 @@ def test_get_process_details_impl_error(mock_get_process_client):
     mock_get_process_client.return_value = mock_process_client
     
     # Simulate error
-    mock_process_client.get_process_by_its_id.side_effect = Exception("Test error")
+    mock_process_client.get_process_by_its_id.side_effect = Exception(
+        "Test error")
     
     # Act
     result = _get_process_details_impl("process-id-123")
     
     # Assert
-    assert "Error retrieving process details for process ID 'process-id-123': Test error" in result
+    assert ("Error retrieving process details for process ID 'process-id-123':"
+            " Test error" in result)
 
 
 @patch("mcp_azure_devops.features.work_items.tools.process.get_work_item_tracking_process_client")
@@ -202,7 +207,8 @@ def test_list_processes_impl(mock_get_process_client):
     mock_properties2.is_default = False
     mock_process2.properties = mock_properties2
     
-    mock_process_client.get_list_of_processes.return_value = [mock_process1, mock_process2]
+    mock_process_client.get_list_of_processes.return_value = [
+        mock_process1, mock_process2]
     
     # Act
     result = _list_processes_impl()
@@ -247,7 +253,8 @@ def test_list_processes_impl_error(mock_get_process_client):
     mock_get_process_client.return_value = mock_process_client
     
     # Simulate error
-    mock_process_client.get_list_of_processes.side_effect = Exception("Test error")
+    mock_process_client.get_list_of_processes.side_effect = Exception(
+        "Test error")
     
     # Act
     result = _list_processes_impl()

--- a/tests/features/work_items/test_process.py
+++ b/tests/features/work_items/test_process.py
@@ -1,0 +1,256 @@
+from unittest.mock import MagicMock, patch
+
+from mcp_azure_devops.features.work_items.tools.process import (
+    _get_process_details_impl,
+    _get_project_process_id_impl,
+    _list_processes_impl,
+)
+
+
+@patch("mcp_azure_devops.features.work_items.tools.process.get_core_client")
+def test_get_project_process_id_impl(mock_get_core_client):
+    """Test retrieving project process ID."""
+    # Arrange
+    mock_core_client = MagicMock()
+    mock_get_core_client.return_value = mock_core_client
+    
+    # Mock project details
+    mock_project = MagicMock()
+    mock_project.name = "Test Project"
+    mock_project.capabilities = {
+        "processTemplate": {
+            "templateTypeId": "process-id-123",
+            "templateName": "Agile"
+        }
+    }
+    
+    mock_core_client.get_project.return_value = mock_project
+    
+    # Act
+    result = _get_project_process_id_impl("Test Project")
+    
+    # Assert
+    mock_core_client.get_project.assert_called_once_with("Test Project", include_capabilities=True)
+    
+    # Check result formatting
+    assert "Process for Project: Test Project" in result
+    assert "Process Name: Agile" in result
+    assert "Process ID: process-id-123" in result
+
+
+@patch("mcp_azure_devops.features.work_items.tools.process.get_core_client")
+def test_get_project_process_id_impl_no_process(mock_get_core_client):
+    """Test retrieving project process ID when no process is found."""
+    # Arrange
+    mock_core_client = MagicMock()
+    mock_get_core_client.return_value = mock_core_client
+    
+    # Mock project details with no process
+    mock_project = MagicMock()
+    mock_project.name = "Test Project"
+    mock_project.capabilities = {
+        "processTemplate": {}  # Empty process template
+    }
+    
+    mock_core_client.get_project.return_value = mock_project
+    
+    # Act
+    result = _get_project_process_id_impl("Test Project")
+    
+    # Assert
+    assert "Could not determine process ID for project Test Project" in result
+
+
+@patch("mcp_azure_devops.features.work_items.tools.process.get_core_client")
+def test_get_project_process_id_impl_error(mock_get_core_client):
+    """Test error handling in get_project_process_id_impl."""
+    # Arrange
+    mock_core_client = MagicMock()
+    mock_get_core_client.return_value = mock_core_client
+    
+    # Simulate error
+    mock_core_client.get_project.side_effect = Exception("Test error")
+    
+    # Act
+    result = _get_project_process_id_impl("Test Project")
+    
+    # Assert
+    assert "Error retrieving process ID for project 'Test Project': Test error" in result
+
+
+@patch("mcp_azure_devops.features.work_items.tools.process.get_work_item_tracking_process_client")
+def test_get_process_details_impl(mock_get_process_client):
+    """Test retrieving process details."""
+    # Arrange
+    mock_process_client = MagicMock()
+    mock_get_process_client.return_value = mock_process_client
+    
+    # Mock process
+    mock_process = MagicMock()
+    mock_process.name = "Agile"
+    mock_process.reference_name = "Agile"
+    mock_process.type_id = "process-id-123"
+    mock_process.description = "Agile process template"
+    
+    # Mock process properties
+    mock_properties = MagicMock()
+    mock_properties.is_default = True
+    mock_properties.is_enabled = True
+    mock_process.properties = mock_properties
+    
+    # Mock work item types
+    mock_wit_type1 = MagicMock()
+    mock_wit_type1.name = "Bug"
+    mock_wit_type1.reference_name = "System.Bug"
+    mock_wit_type1.description = "Represents a bug or defect"
+    
+    mock_wit_type2 = MagicMock()
+    mock_wit_type2.name = "Task"
+    mock_wit_type2.reference_name = "System.Task"
+    mock_wit_type2.description = "Represents a task item"
+    
+    mock_process_client.get_process_by_its_id.return_value = mock_process
+    mock_process_client.get_process_work_item_types.return_value = [mock_wit_type1, mock_wit_type2]
+    
+    # Act
+    result = _get_process_details_impl("process-id-123")
+    
+    # Assert
+    mock_process_client.get_process_by_its_id.assert_called_once_with("process-id-123")
+    mock_process_client.get_process_work_item_types.assert_called_once_with("process-id-123")
+    
+    # Check result formatting
+    assert "Process: Agile" in result
+    assert "Description: Agile process template" in result
+    assert "Reference Name: Agile" in result
+    assert "Type ID: process-id-123" in result
+    
+    # Check properties section
+    assert "Properties" in result
+    assert "Is default: True" in result
+    assert "Is enabled: True" in result
+    
+    # Check work item types section
+    assert "Work Item Types" in result
+    assert "Bug" in result
+    assert "System.Bug" in result
+    assert "Represents a bug or defect" in result
+    assert "Task" in result
+    assert "System.Task" in result
+    assert "Represents a task item" in result
+
+
+@patch("mcp_azure_devops.features.work_items.tools.process.get_work_item_tracking_process_client")
+def test_get_process_details_impl_not_found(mock_get_process_client):
+    """Test retrieving process details when process is not found."""
+    # Arrange
+    mock_process_client = MagicMock()
+    mock_get_process_client.return_value = mock_process_client
+    
+    # Process not found
+    mock_process_client.get_process_by_its_id.return_value = None
+    
+    # Act
+    result = _get_process_details_impl("non-existent-id")
+    
+    # Assert
+    assert "Process with ID 'non-existent-id' not found" in result
+
+
+@patch("mcp_azure_devops.features.work_items.tools.process.get_work_item_tracking_process_client")
+def test_get_process_details_impl_error(mock_get_process_client):
+    """Test error handling in get_process_details_impl."""
+    # Arrange
+    mock_process_client = MagicMock()
+    mock_get_process_client.return_value = mock_process_client
+    
+    # Simulate error
+    mock_process_client.get_process_by_its_id.side_effect = Exception("Test error")
+    
+    # Act
+    result = _get_process_details_impl("process-id-123")
+    
+    # Assert
+    assert "Error retrieving process details for process ID 'process-id-123': Test error" in result
+
+
+@patch("mcp_azure_devops.features.work_items.tools.process.get_work_item_tracking_process_client")
+def test_list_processes_impl(mock_get_process_client):
+    """Test listing all processes."""
+    # Arrange
+    mock_process_client = MagicMock()
+    mock_get_process_client.return_value = mock_process_client
+    
+    # Mock processes
+    mock_process1 = MagicMock()
+    mock_process1.name = "Agile"
+    mock_process1.type_id = "process-id-123"
+    mock_process1.reference_name = "Agile"
+    mock_process1.description = "Agile process template"
+    
+    mock_properties1 = MagicMock()
+    mock_properties1.is_default = True
+    mock_process1.properties = mock_properties1
+    
+    mock_process2 = MagicMock()
+    mock_process2.name = "Scrum"
+    mock_process2.type_id = "process-id-456"
+    mock_process2.reference_name = "Scrum"
+    mock_process2.description = "Scrum process template"
+    
+    mock_properties2 = MagicMock()
+    mock_properties2.is_default = False
+    mock_process2.properties = mock_properties2
+    
+    mock_process_client.get_list_of_processes.return_value = [mock_process1, mock_process2]
+    
+    # Act
+    result = _list_processes_impl()
+    
+    # Assert
+    mock_process_client.get_list_of_processes.assert_called_once()
+    
+    # Check result formatting
+    assert "Available Processes" in result
+    assert "Agile" in result
+    assert "process-id-123" in result
+    assert "Agile process template" in result
+    assert "Yes" in result  # For is_default=True
+    assert "Scrum" in result
+    assert "process-id-456" in result
+    assert "Scrum process template" in result
+    assert "No" in result  # For is_default=False
+
+
+@patch("mcp_azure_devops.features.work_items.tools.process.get_work_item_tracking_process_client")
+def test_list_processes_impl_no_processes(mock_get_process_client):
+    """Test listing processes when none exist."""
+    # Arrange
+    mock_process_client = MagicMock()
+    mock_get_process_client.return_value = mock_process_client
+    
+    # No processes
+    mock_process_client.get_list_of_processes.return_value = []
+    
+    # Act
+    result = _list_processes_impl()
+    
+    # Assert
+    assert "No processes found in the organization" in result
+
+
+@patch("mcp_azure_devops.features.work_items.tools.process.get_work_item_tracking_process_client")
+def test_list_processes_impl_error(mock_get_process_client):
+    """Test error handling in list_processes_impl."""
+    # Arrange
+    mock_process_client = MagicMock()
+    mock_get_process_client.return_value = mock_process_client
+    
+    # Simulate error
+    mock_process_client.get_list_of_processes.side_effect = Exception("Test error")
+    
+    # Act
+    result = _list_processes_impl()
+    
+    # Assert
+    assert "Error retrieving processes: Test error" in result

--- a/tests/features/work_items/test_templates.py
+++ b/tests/features/work_items/test_templates.py
@@ -102,7 +102,8 @@ def test_get_work_item_template_impl():
     }
     
     # Act
-    result = _get_work_item_template_impl(team_context, "template1", mock_client)
+    result = _get_work_item_template_impl(
+        team_context, "template1", mock_client)
     
     # Assert
     mock_client.get_template.assert_called_once()
@@ -131,7 +132,8 @@ def test_get_work_item_template_impl_not_found():
     }
     
     # Act
-    result = _get_work_item_template_impl(team_context, "non-existent", mock_client)
+    result = _get_work_item_template_impl(
+        team_context, "non-existent", mock_client)
     
     # Assert
     mock_client.get_template.assert_called_once()
@@ -150,7 +152,8 @@ def test_get_work_item_template_impl_error_handling():
     }
     
     # Act
-    result = _get_work_item_template_impl(team_context, "template1", mock_client)
+    result = _get_work_item_template_impl(
+        team_context, "template1", mock_client)
     
     # Assert
     assert "Error retrieving template 'template1': Test error" in result

--- a/tests/features/work_items/test_templates.py
+++ b/tests/features/work_items/test_templates.py
@@ -1,0 +1,156 @@
+from unittest.mock import MagicMock, patch
+
+from azure.devops.v7_1.work_item_tracking.models import TeamContext, WorkItemTemplate
+
+from mcp_azure_devops.features.work_items.tools.templates import (
+    _get_work_item_templates_impl,
+    _get_work_item_template_impl,
+)
+
+
+def test_get_work_item_templates_impl_with_templates():
+    """Test retrieving work item templates."""
+    # Arrange
+    mock_client = MagicMock()
+    
+    # Create mock templates
+    mock_template1 = MagicMock(spec=WorkItemTemplate)
+    mock_template1.id = "template1"
+    mock_template1.name = "Bug Template"
+    mock_template1.description = "Template for bugs"
+    mock_template1.work_item_type_name = "Bug"
+    mock_template1.fields = {
+        "System.Title": "New Bug",
+        "System.Description": "Bug description"
+    }
+    
+    mock_template2 = MagicMock(spec=WorkItemTemplate)
+    mock_template2.id = "template2"
+    mock_template2.name = "Task Template"
+    mock_template2.description = "Template for tasks"
+    mock_template2.work_item_type_name = "Task"
+    mock_template2.fields = {
+        "System.Title": "New Task",
+        "System.Description": "Task description"
+    }
+    
+    mock_client.get_templates.return_value = [mock_template1, mock_template2]
+    
+    team_context = {
+        "project": "TestProject",
+        "team": "TestTeam"
+    }
+    
+    # Act
+    result = _get_work_item_templates_impl(team_context, "Bug", mock_client)
+    
+    # Assert
+    mock_client.get_templates.assert_called_once()
+    
+    # Verify the table contents
+    assert "Work Item Templates for Team: TestTeam" in result
+    assert "Filtered by type: Bug" in result
+    assert "Bug Template" in result
+    assert "Template for bugs" in result
+    assert "Bug" in result
+    assert "Task Template" in result
+    assert "Task" in result
+
+
+def test_get_work_item_templates_impl_no_templates():
+    """Test retrieving work item templates when none exist."""
+    # Arrange
+    mock_client = MagicMock()
+    mock_client.get_templates.return_value = []
+    
+    team_context = {
+        "project": "TestProject",
+        "team": "TestTeam"
+    }
+    
+    # Act
+    result = _get_work_item_templates_impl(team_context, "Bug", mock_client)
+    
+    # Assert
+    mock_client.get_templates.assert_called_once()
+    assert "No templates found for work item type 'Bug'" in result
+    assert "team TestTeam" in result
+
+
+def test_get_work_item_template_impl():
+    """Test retrieving a specific work item template."""
+    # Arrange
+    mock_client = MagicMock()
+    
+    # Create mock template
+    mock_template = MagicMock(spec=WorkItemTemplate)
+    mock_template.id = "template1"
+    mock_template.name = "Bug Template"
+    mock_template.description = "Template for bugs"
+    mock_template.work_item_type_name = "Bug"
+    mock_template.fields = {
+        "System.Title": "New Bug",
+        "System.Description": "Bug description",
+        "Microsoft.VSTS.Common.Priority": 2
+    }
+    
+    mock_client.get_template.return_value = mock_template
+    
+    team_context = {
+        "project": "TestProject",
+        "team": "TestTeam"
+    }
+    
+    # Act
+    result = _get_work_item_template_impl(team_context, "template1", mock_client)
+    
+    # Assert
+    mock_client.get_template.assert_called_once()
+    assert "Template: Bug Template" in result
+    assert "Description: Template for bugs" in result
+    assert "Work item type name: Bug" in result
+    assert "Id: template1" in result
+    assert "Default Field Values" in result
+    assert "System.Title" in result
+    assert "New Bug" in result
+    assert "System.Description" in result
+    assert "Bug description" in result
+    assert "Microsoft.VSTS.Common.Priority" in result
+    assert "2" in result
+
+
+def test_get_work_item_template_impl_not_found():
+    """Test retrieving a template that doesn't exist."""
+    # Arrange
+    mock_client = MagicMock()
+    mock_client.get_template.return_value = None
+    
+    team_context = {
+        "project": "TestProject",
+        "team": "TestTeam"
+    }
+    
+    # Act
+    result = _get_work_item_template_impl(team_context, "non-existent", mock_client)
+    
+    # Assert
+    mock_client.get_template.assert_called_once()
+    assert "Template with ID 'non-existent' not found" in result
+
+
+def test_get_work_item_template_impl_error_handling():
+    """Test error handling in get_work_item_template_impl."""
+    # Arrange
+    mock_client = MagicMock()
+    mock_client.get_template.side_effect = Exception("Test error")
+    
+    team_context = {
+        "project": "TestProject",
+        "team": "TestTeam"
+    }
+    
+    # Act
+    result = _get_work_item_template_impl(team_context, "template1", mock_client)
+    
+    # Assert
+    assert "Error retrieving template 'template1': Test error" in result

--- a/tests/features/work_items/test_templates.py
+++ b/tests/features/work_items/test_templates.py
@@ -1,10 +1,10 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-from azure.devops.v7_1.work_item_tracking.models import TeamContext, WorkItemTemplate
+from azure.devops.v7_1.work_item_tracking.models import WorkItemTemplate
 
 from mcp_azure_devops.features.work_items.tools.templates import (
-    _get_work_item_templates_impl,
     _get_work_item_template_impl,
+    _get_work_item_templates_impl,
 )
 
 

--- a/tests/features/work_items/test_tools.py
+++ b/tests/features/work_items/test_tools.py
@@ -60,7 +60,8 @@ def test_query_work_items_impl_with_results():
     
     result = _query_work_items_impl("SELECT * FROM WorkItems", 10, mock_client)
     
-    # Check that the result contains the expected formatting per format_work_item
+    # Check that the result contains the expected formatting 
+    # per format_work_item
     assert "# Work Item 123" in result
     assert "- **System.WorkItemType**: Bug" in result
     assert "- **System.Title**: Test Bug" in result

--- a/tests/features/work_items/test_tools.py
+++ b/tests/features/work_items/test_tools.py
@@ -60,13 +60,15 @@ def test_query_work_items_impl_with_results():
     
     result = _query_work_items_impl("SELECT * FROM WorkItems", 10, mock_client)
     
-    # Check that the result contains the expected basic info formatting
-    assert "# Work Item 123: Test Bug" in result
-    assert "Type: Bug" in result
-    assert "State: Active" in result
-    assert "# Work Item 456: Test Task" in result
-    assert "Type: Task" in result
-    assert "State: Closed" in result
+    # Check that the result contains the expected formatting per format_work_item
+    assert "# Work Item 123" in result
+    assert "- **System.WorkItemType**: Bug" in result
+    assert "- **System.Title**: Test Bug" in result
+    assert "- **System.State**: Active" in result
+    assert "# Work Item 456" in result
+    assert "- **System.WorkItemType**: Task" in result
+    assert "- **System.Title**: Test Task" in result
+    assert "- **System.State**: Closed" in result
 
 
 # Tests for _get_work_item_impl
@@ -88,10 +90,11 @@ def test_get_work_item_impl_basic():
     result = _get_work_item_impl(123, mock_client)
     
     # Check that the result contains expected basic info
-    assert "# Work Item 123: Test Bug" in result
-    assert "Type: Bug" in result
-    assert "State: Active" in result
-    assert "Project: Test Project" in result
+    assert "# Work Item 123" in result
+    assert "- **System.WorkItemType**: Bug" in result
+    assert "- **System.Title**: Test Bug" in result
+    assert "- **System.State**: Active" in result
+    assert "- **System.TeamProject**: Test Project" in result
 
 def test_get_work_item_impl_detailed():
     """Test retrieving detailed work item info."""
@@ -121,13 +124,14 @@ def test_get_work_item_impl_detailed():
     result = _get_work_item_impl(123, mock_client)
     
     # Check that the result contains both basic and detailed info
-    assert "# Work Item 123: Test Bug" in result
-    assert "Type: Bug" in result
-    assert "Description" in result
-    assert "This is a description" in result
-    assert "Assigned To: Test User (test@example.com)" in result
-    assert "Created By: Creator User" in result
-    assert "Iteration: Project\\Sprint 1" in result
+    assert "# Work Item 123" in result
+    assert "- **System.WorkItemType**: Bug" in result
+    assert "- **System.Description**: This is a description" in result
+    assert "- **System.AssignedTo**: Test User (test@example.com)" in result
+    assert "- **System.CreatedBy**: Creator User" in result
+    assert "- **System.IterationPath**: Project\\Sprint 1" in result
+    assert "- **System.AreaPath**: Project\\Area" in result
+    assert "- **System.Tags**: tag1; tag2" in result
 
 def test_get_work_item_impl_error():
     """Test error handling in get_work_item_impl."""

--- a/tests/features/work_items/test_types.py
+++ b/tests/features/work_items/test_types.py
@@ -30,7 +30,8 @@ def test_get_work_item_types_impl():
     mock_task_type.color = "00FF00"
     mock_task_type.icon = "task"
     
-    mock_client.get_work_item_types.return_value = [mock_bug_type, mock_task_type]
+    mock_client.get_work_item_types.return_value = [
+        mock_bug_type, mock_task_type]
     
     # Act
     result = _get_work_item_types_impl("TestProject", mock_client)
@@ -102,7 +103,8 @@ def test_get_work_item_type_impl():
     result = _get_work_item_type_impl("TestProject", "Bug", mock_client)
     
     # Assert
-    mock_client.get_work_item_type.assert_called_once_with("TestProject", "Bug")
+    mock_client.get_work_item_type.assert_called_once_with(
+        "TestProject", "Bug")
     
     # Check result content
     assert "Work Item Type: Bug" in result or "# Work Item Type: Bug" in result
@@ -130,16 +132,20 @@ def test_get_work_item_type_impl_not_found():
     mock_client.get_work_item_type.return_value = None
     
     # Act
-    result = _get_work_item_type_impl("TestProject", "NonExistentType", mock_client)
+    result = _get_work_item_type_impl(
+        "TestProject", "NonExistentType", mock_client)
     
     # Assert
-    mock_client.get_work_item_type.assert_called_once_with("TestProject", "NonExistentType")
-    assert "Work item type 'NonExistentType' not found in project TestProject" in result
+    mock_client.get_work_item_type.assert_called_once_with(
+        "TestProject", "NonExistentType")
+    assert ("Work item type 'NonExistentType' not found in project " 
+            "TestProject" in result)
 
 
 @patch("mcp_azure_devops.features.work_items.tools.types.get_core_client")
 @patch("mcp_azure_devops.features.work_items.tools.types.get_work_item_tracking_process_client")
-def test_get_work_item_type_fields_impl(mock_get_process_client, mock_get_core_client):
+def test_get_work_item_type_fields_impl(
+        mock_get_process_client, mock_get_core_client):
     """Test retrieving all fields for a work item type."""
     # Arrange
     mock_wit_client = MagicMock()
@@ -190,12 +196,16 @@ def test_get_work_item_type_fields_impl(mock_get_process_client, mock_get_core_c
     mock_get_process_client.return_value = mock_process_client
     
     # Act
-    result = _get_work_item_type_fields_impl("TestProject", "Bug", mock_wit_client)
+    result = _get_work_item_type_fields_impl(
+        "TestProject", "Bug", mock_wit_client)
     
     # Assert
-    mock_wit_client.get_work_item_type.assert_called_once_with("TestProject", "Bug")
-    mock_core_client.get_project.assert_called_once_with("TestProject", include_capabilities=True)
-    mock_process_client.get_all_work_item_type_fields.assert_called_once_with("process-id-123", "System.Bug")
+    mock_wit_client.get_work_item_type.assert_called_once_with(
+        "TestProject", "Bug")
+    mock_core_client.get_project.assert_called_once_with(
+        "TestProject", include_capabilities=True)
+    mock_process_client.get_all_work_item_type_fields.assert_called_once_with(
+        "process-id-123", "System.Bug")
     
     # Check result content
     assert "Fields for Work Item Type: Bug" in result
@@ -214,7 +224,8 @@ def test_get_work_item_type_fields_impl(mock_get_process_client, mock_get_core_c
 
 @patch("mcp_azure_devops.features.work_items.tools.types.get_core_client")
 @patch("mcp_azure_devops.features.work_items.tools.types.get_work_item_tracking_process_client")
-def test_get_work_item_type_fields_impl_no_fields(mock_get_process_client, mock_get_core_client):
+def test_get_work_item_type_fields_impl_no_fields(
+        mock_get_process_client, mock_get_core_client):
     """Test retrieving fields when none exist."""
     # Arrange
     mock_wit_client = MagicMock()
@@ -242,15 +253,18 @@ def test_get_work_item_type_fields_impl_no_fields(mock_get_process_client, mock_
     mock_get_process_client.return_value = mock_process_client
     
     # Act
-    result = _get_work_item_type_fields_impl("TestProject", "Bug", mock_wit_client)
+    result = _get_work_item_type_fields_impl(
+        "TestProject", "Bug", mock_wit_client)
     
     # Assert
-    assert "No fields found for work item type 'Bug' in project TestProject" in result
+    assert ("No fields found for work item type 'Bug' in project TestProject" 
+            in result)
 
 
 @patch("mcp_azure_devops.features.work_items.tools.types.get_core_client")
 @patch("mcp_azure_devops.features.work_items.tools.types.get_work_item_tracking_process_client")
-def test_get_work_item_type_field_impl(mock_get_process_client, mock_get_core_client):
+def test_get_work_item_type_field_impl(
+        mock_get_process_client, mock_get_core_client):
     """Test retrieving a specific field for a work item type."""
     # Arrange
     mock_wit_client = MagicMock()
@@ -283,18 +297,22 @@ def test_get_work_item_type_field_impl(mock_get_process_client, mock_get_core_cl
     mock_priority_field.allowed_values = ["1", "2", "3", "4"]
     mock_priority_field.default_value = "3"
     
-    mock_process_client.get_work_item_type_field.return_value = mock_priority_field
+    mock_process_client.get_work_item_type_field.return_value = (
+        mock_priority_field)
     mock_get_process_client.return_value = mock_process_client
     
     # Use reference name directly for this test
     field_name = "Microsoft.VSTS.Common.Priority"
     
     # Act
-    result = _get_work_item_type_field_impl("TestProject", "Bug", field_name, mock_wit_client)
+    result = _get_work_item_type_field_impl(
+        "TestProject", "Bug", field_name, mock_wit_client)
     
     # Assert
-    mock_wit_client.get_work_item_type.assert_called_once_with("TestProject", "Bug")
-    mock_core_client.get_project.assert_called_once_with("TestProject", include_capabilities=True)
+    mock_wit_client.get_work_item_type.assert_called_once_with(
+        "TestProject", "Bug")
+    mock_core_client.get_project.assert_called_once_with(
+        "TestProject", include_capabilities=True)
     # Verify the mock method was called in some manner
     assert mock_process_client.get_work_item_type_field.call_count > 0
     
@@ -314,7 +332,8 @@ def test_get_work_item_type_field_impl(mock_get_process_client, mock_get_core_cl
 
 @patch("mcp_azure_devops.features.work_items.tools.types.get_core_client")
 @patch("mcp_azure_devops.features.work_items.tools.types.get_work_item_tracking_process_client")
-def test_get_work_item_type_field_impl_display_name(mock_get_process_client, mock_get_core_client):
+def test_get_work_item_type_field_impl_display_name(
+        mock_get_process_client, mock_get_core_client):
     """Test retrieving a field by display name instead of reference name."""
     # Arrange
     mock_wit_client = MagicMock()
@@ -337,12 +356,14 @@ def test_get_work_item_type_field_impl_display_name(mock_get_process_client, moc
     mock_core_client.get_project.return_value = mock_project
     mock_get_core_client.return_value = mock_core_client
     
-    # Setup mock for get_all_work_item_type_fields (used to find reference name)
+    # Setup mock for get_all_work_item_type_fields 
+    # (used to find reference name)
     mock_priority_field = MagicMock()
     mock_priority_field.name = "Priority"
     mock_priority_field.reference_name = "Microsoft.VSTS.Common.Priority"
     
-    mock_process_client.get_all_work_item_type_fields.return_value = [mock_priority_field]
+    mock_process_client.get_all_work_item_type_fields.return_value = [
+        mock_priority_field]
     
     # Setup mock for get_work_item_type_field
     mock_field_detail = MagicMock()
@@ -353,22 +374,27 @@ def test_get_work_item_type_field_impl_display_name(mock_get_process_client, moc
     mock_field_detail.read_only = False
     mock_field_detail.allowed_values = ["1", "2", "3", "4"]
     
-    mock_process_client.get_work_item_type_field.return_value = mock_field_detail
+    mock_process_client.get_work_item_type_field.return_value = (
+        mock_field_detail)
     mock_get_process_client.return_value = mock_process_client
     
     # Use display name for this test
     field_name = "Priority"
     
     # Act
-    result = _get_work_item_type_field_impl("TestProject", "Bug", field_name, mock_wit_client)
+    result = _get_work_item_type_field_impl(
+        "TestProject", "Bug", field_name, mock_wit_client)
     
     # Assert
     # First verify it looked up all fields to find reference name
-    mock_process_client.get_all_work_item_type_fields.assert_called_once_with("process-id-123", "System.Bug")
+    mock_process_client.get_all_work_item_type_fields.assert_called_once_with(
+        "process-id-123", "System.Bug")
     
     # Then verify it called get_work_item_type_field with the reference name
-    # Handle the different ways the implementation might call the process client
-    # The test might be expecting a specific method call, but the implementation might be different
+    # Handle the different ways the implementation might call 
+    # the process client
+    # The test might be expecting a specific method call, 
+    # but the implementation might be different
     assert mock_process_client.get_work_item_type_field.call_count > 0
     mock_process_client.get_work_item_type_field.assert_any_call(
         "process-id-123", "System.Bug", "Microsoft.VSTS.Common.Priority"
@@ -381,7 +407,8 @@ def test_get_work_item_type_field_impl_display_name(mock_get_process_client, moc
 
 @patch("mcp_azure_devops.features.work_items.tools.types.get_core_client")
 @patch("mcp_azure_devops.features.work_items.tools.types.get_work_item_tracking_process_client")
-def test_get_work_item_type_field_impl_field_not_found(mock_get_process_client, mock_get_core_client):
+def test_get_work_item_type_field_impl_field_not_found(
+        mock_get_process_client, mock_get_core_client):
     """Test retrieving a field that doesn't exist."""
     # Arrange
     mock_wit_client = MagicMock()
@@ -412,7 +439,9 @@ def test_get_work_item_type_field_impl_field_not_found(mock_get_process_client, 
     field_name = "NonExistentField"
     
     # Act
-    result = _get_work_item_type_field_impl("TestProject", "Bug", field_name, mock_wit_client)
+    result = _get_work_item_type_field_impl(
+        "TestProject", "Bug", field_name, mock_wit_client)
     
     # Assert
-    assert f"Field '{field_name}' not found for work item type 'Bug' in project 'TestProject'" in result
+    assert (f"Field '{field_name}' not found for work item type " 
+            f"'Bug' in project 'TestProject'" in result)

--- a/tests/features/work_items/test_types.py
+++ b/tests/features/work_items/test_types.py
@@ -1,0 +1,418 @@
+from unittest.mock import MagicMock, patch
+
+from azure.devops.v7_1.work_item_tracking.models import WorkItemType, WorkItemTypeField
+
+from mcp_azure_devops.features.work_items.tools.types import (
+    _get_work_item_types_impl,
+    _get_work_item_type_impl,
+    _get_work_item_type_fields_impl,
+    _get_work_item_type_field_impl,
+)
+from mcp_azure_devops.utils.azure_client import (
+    get_core_client,
+    get_work_item_tracking_process_client,
+)
+
+
+def test_get_work_item_types_impl():
+    """Test retrieving all work item types."""
+    # Arrange
+    mock_client = MagicMock()
+    
+    # Create mock work item types
+    mock_bug_type = MagicMock(spec=WorkItemType)
+    mock_bug_type.name = "Bug"
+    mock_bug_type.reference_name = "System.Bug"
+    mock_bug_type.description = "Represents a bug or defect"
+    mock_bug_type.color = "FF0000"
+    mock_bug_type.icon = "bug"
+    
+    mock_task_type = MagicMock(spec=WorkItemType)
+    mock_task_type.name = "Task"
+    mock_task_type.reference_name = "System.Task"
+    mock_task_type.description = "Represents a task item"
+    mock_task_type.color = "00FF00"
+    mock_task_type.icon = "task"
+    
+    mock_client.get_work_item_types.return_value = [mock_bug_type, mock_task_type]
+    
+    # Act
+    result = _get_work_item_types_impl("TestProject", mock_client)
+    
+    # Assert
+    mock_client.get_work_item_types.assert_called_once_with("TestProject")
+    
+    # Check result content
+    assert "Work Item Types in Project: TestProject" in result
+    assert "Bug" in result
+    assert "System.Bug" in result
+    assert "Represents a bug or defect" in result
+    assert "Task" in result
+    assert "System.Task" in result
+    assert "Represents a task item" in result
+
+
+def test_get_work_item_types_impl_no_types():
+    """Test retrieving work item types when none exist."""
+    # Arrange
+    mock_client = MagicMock()
+    mock_client.get_work_item_types.return_value = []
+    
+    # Act
+    result = _get_work_item_types_impl("TestProject", mock_client)
+    
+    # Assert
+    mock_client.get_work_item_types.assert_called_once_with("TestProject")
+    assert "No work item types found in project TestProject" in result
+
+
+def test_get_work_item_type_impl():
+    """Test retrieving a specific work item type."""
+    # Arrange
+    mock_client = MagicMock()
+    
+    # Create mock work item type with states
+    mock_state1 = MagicMock()
+    mock_state1.name = "New"
+    mock_state1.color = "0000FF"
+    mock_state1.category = "Proposed"
+    
+    mock_state2 = MagicMock()
+    mock_state2.name = "Active"
+    mock_state2.color = "00FF00"
+    mock_state2.category = "InProgress"
+    
+    mock_state3 = MagicMock()
+    mock_state3.name = "Resolved"
+    mock_state3.color = "FFFF00"
+    mock_state3.category = "Resolved"
+    
+    mock_state4 = MagicMock()
+    mock_state4.name = "Closed"
+    mock_state4.color = "008000"
+    mock_state4.category = "Completed"
+    
+    mock_bug_type = MagicMock(spec=WorkItemType)
+    mock_bug_type.name = "Bug"
+    mock_bug_type.reference_name = "System.Bug"
+    mock_bug_type.description = "Represents a bug or defect"
+    mock_bug_type.color = "FF0000"
+    mock_bug_type.icon = "bug"
+    mock_bug_type.states = [mock_state1, mock_state2, mock_state3, mock_state4]
+    
+    mock_client.get_work_item_type.return_value = mock_bug_type
+    
+    # Act
+    result = _get_work_item_type_impl("TestProject", "Bug", mock_client)
+    
+    # Assert
+    mock_client.get_work_item_type.assert_called_once_with("TestProject", "Bug")
+    
+    # Check result content
+    assert "Work Item Type: Bug" in result
+    assert "Description: Represents a bug or defect" in result
+    assert "Color: FF0000" in result
+    assert "Icon: bug" in result
+    assert "Reference name: System.Bug" in result
+    
+    # Check states section
+    assert "States" in result
+    assert "New" in result
+    assert "Active" in result
+    assert "Resolved" in result
+    assert "Closed" in result
+    assert "Category: Proposed" in result
+    assert "Color: 0000FF" in result
+    assert "Category: Completed" in result
+    assert "Color: 008000" in result
+
+
+def test_get_work_item_type_impl_not_found():
+    """Test retrieving a work item type that doesn't exist."""
+    # Arrange
+    mock_client = MagicMock()
+    mock_client.get_work_item_type.return_value = None
+    
+    # Act
+    result = _get_work_item_type_impl("TestProject", "NonExistentType", mock_client)
+    
+    # Assert
+    mock_client.get_work_item_type.assert_called_once_with("TestProject", "NonExistentType")
+    assert "Work item type 'NonExistentType' not found in project TestProject" in result
+
+
+@patch("mcp_azure_devops.features.work_items.tools.types.get_core_client")
+@patch("mcp_azure_devops.features.work_items.tools.types.get_work_item_tracking_process_client")
+def test_get_work_item_type_fields_impl(mock_get_process_client, mock_get_core_client):
+    """Test retrieving all fields for a work item type."""
+    # Arrange
+    mock_wit_client = MagicMock()
+    mock_core_client = MagicMock()
+    mock_process_client = MagicMock()
+    
+    # Setup mock for get_work_item_type
+    mock_bug_type = MagicMock(spec=WorkItemType)
+    mock_bug_type.name = "Bug"
+    mock_bug_type.reference_name = "System.Bug"
+    mock_wit_client.get_work_item_type.return_value = mock_bug_type
+    
+    # Setup mock for get_project from core client
+    mock_project = MagicMock()
+    mock_project.capabilities = {
+        "processTemplate": {
+            "templateTypeId": "process-id-123"
+        }
+    }
+    mock_core_client.get_project.return_value = mock_project
+    mock_get_core_client.return_value = mock_core_client
+    
+    # Setup mock for get_all_work_item_type_fields
+    mock_title_field = MagicMock(spec=WorkItemTypeField)
+    mock_title_field.name = "Title"
+    mock_title_field.reference_name = "System.Title"
+    mock_title_field.type = "string"
+    mock_title_field.required = True
+    mock_title_field.read_only = False
+    
+    mock_desc_field = MagicMock(spec=WorkItemTypeField)
+    mock_desc_field.name = "Description"
+    mock_desc_field.reference_name = "System.Description"
+    mock_desc_field.type = "html"
+    mock_desc_field.required = False
+    mock_desc_field.read_only = False
+    
+    mock_priority_field = MagicMock(spec=WorkItemTypeField)
+    mock_priority_field.name = "Priority"
+    mock_priority_field.reference_name = "Microsoft.VSTS.Common.Priority"
+    mock_priority_field.type = "integer"
+    mock_priority_field.required = False
+    mock_priority_field.read_only = False
+    
+    mock_process_client.get_all_work_item_type_fields.return_value = [
+        mock_title_field, mock_desc_field, mock_priority_field
+    ]
+    mock_get_process_client.return_value = mock_process_client
+    
+    # Act
+    result = _get_work_item_type_fields_impl("TestProject", "Bug", mock_wit_client)
+    
+    # Assert
+    mock_wit_client.get_work_item_type.assert_called_once_with("TestProject", "Bug")
+    mock_core_client.get_project.assert_called_once_with("TestProject", include_capabilities=True)
+    mock_process_client.get_all_work_item_type_fields.assert_called_once_with("process-id-123", "System.Bug")
+    
+    # Check result content
+    assert "Fields for Work Item Type: Bug" in result
+    assert "Title" in result
+    assert "System.Title" in result
+    assert "string" in result
+    assert "Yes" in result  # For required
+    assert "No" in result   # For read-only
+    assert "Description" in result
+    assert "System.Description" in result
+    assert "html" in result
+    assert "Priority" in result
+    assert "Microsoft.VSTS.Common.Priority" in result
+    assert "integer" in result
+
+
+@patch("mcp_azure_devops.features.work_items.tools.types.get_core_client")
+@patch("mcp_azure_devops.features.work_items.tools.types.get_work_item_tracking_process_client")
+def test_get_work_item_type_fields_impl_no_fields(mock_get_process_client, mock_get_core_client):
+    """Test retrieving fields when none exist."""
+    # Arrange
+    mock_wit_client = MagicMock()
+    mock_core_client = MagicMock()
+    mock_process_client = MagicMock()
+    
+    # Setup mock for get_work_item_type
+    mock_bug_type = MagicMock(spec=WorkItemType)
+    mock_bug_type.name = "Bug"
+    mock_bug_type.reference_name = "System.Bug"
+    mock_wit_client.get_work_item_type.return_value = mock_bug_type
+    
+    # Setup mock for get_project from core client
+    mock_project = MagicMock()
+    mock_project.capabilities = {
+        "processTemplate": {
+            "templateTypeId": "process-id-123"
+        }
+    }
+    mock_core_client.get_project.return_value = mock_project
+    mock_get_core_client.return_value = mock_core_client
+    
+    # Setup mock for get_all_work_item_type_fields - empty
+    mock_process_client.get_all_work_item_type_fields.return_value = []
+    mock_get_process_client.return_value = mock_process_client
+    
+    # Act
+    result = _get_work_item_type_fields_impl("TestProject", "Bug", mock_wit_client)
+    
+    # Assert
+    assert "No fields found for work item type 'Bug' in project TestProject" in result
+
+
+@patch("mcp_azure_devops.features.work_items.tools.types.get_core_client")
+@patch("mcp_azure_devops.features.work_items.tools.types.get_work_item_tracking_process_client")
+def test_get_work_item_type_field_impl(mock_get_process_client, mock_get_core_client):
+    """Test retrieving a specific field for a work item type."""
+    # Arrange
+    mock_wit_client = MagicMock()
+    mock_core_client = MagicMock()
+    mock_process_client = MagicMock()
+    
+    # Setup mock for get_work_item_type
+    mock_bug_type = MagicMock(spec=WorkItemType)
+    mock_bug_type.name = "Bug"
+    mock_bug_type.reference_name = "System.Bug"
+    mock_wit_client.get_work_item_type.return_value = mock_bug_type
+    
+    # Setup mock for get_project from core client
+    mock_project = MagicMock()
+    mock_project.capabilities = {
+        "processTemplate": {
+            "templateTypeId": "process-id-123"
+        }
+    }
+    mock_core_client.get_project.return_value = mock_project
+    mock_get_core_client.return_value = mock_core_client
+    
+    # Setup mock for get_work_item_type_field
+    mock_priority_field = MagicMock(spec=WorkItemTypeField)
+    mock_priority_field.name = "Priority"
+    mock_priority_field.reference_name = "Microsoft.VSTS.Common.Priority"
+    mock_priority_field.type = "integer"
+    mock_priority_field.required = False
+    mock_priority_field.read_only = False
+    mock_priority_field.allowed_values = ["1", "2", "3", "4"]
+    mock_priority_field.default_value = "3"
+    
+    mock_process_client.get_work_item_type_field.return_value = mock_priority_field
+    mock_get_process_client.return_value = mock_process_client
+    
+    # Use reference name directly for this test
+    field_name = "Microsoft.VSTS.Common.Priority"
+    
+    # Act
+    result = _get_work_item_type_field_impl("TestProject", "Bug", field_name, mock_wit_client)
+    
+    # Assert
+    mock_wit_client.get_work_item_type.assert_called_once_with("TestProject", "Bug")
+    mock_core_client.get_project.assert_called_once_with("TestProject", include_capabilities=True)
+    mock_process_client.get_work_item_type_field.assert_called_once_with("process-id-123", "System.Bug", field_name)
+    
+    # Check result content
+    assert "Field: Priority" in result
+    assert "Reference Name: Microsoft.VSTS.Common.Priority" in result
+    assert "Type: integer" in result
+    assert "Required: No" in result
+    assert "Read Only: No" in result
+    assert "Allowed Values" in result
+    assert "1" in result
+    assert "2" in result
+    assert "3" in result
+    assert "4" in result
+    assert "Default Value: 3" in result
+
+
+@patch("mcp_azure_devops.features.work_items.tools.types.get_core_client")
+@patch("mcp_azure_devops.features.work_items.tools.types.get_work_item_tracking_process_client")
+def test_get_work_item_type_field_impl_display_name(mock_get_process_client, mock_get_core_client):
+    """Test retrieving a field by display name instead of reference name."""
+    # Arrange
+    mock_wit_client = MagicMock()
+    mock_core_client = MagicMock()
+    mock_process_client = MagicMock()
+    
+    # Setup mock for get_work_item_type
+    mock_bug_type = MagicMock(spec=WorkItemType)
+    mock_bug_type.name = "Bug"
+    mock_bug_type.reference_name = "System.Bug"
+    mock_wit_client.get_work_item_type.return_value = mock_bug_type
+    
+    # Setup mock for get_project from core client
+    mock_project = MagicMock()
+    mock_project.capabilities = {
+        "processTemplate": {
+            "templateTypeId": "process-id-123"
+        }
+    }
+    mock_core_client.get_project.return_value = mock_project
+    mock_get_core_client.return_value = mock_core_client
+    
+    # Setup mock for get_all_work_item_type_fields (used to find reference name)
+    mock_priority_field = MagicMock(spec=WorkItemTypeField)
+    mock_priority_field.name = "Priority"
+    mock_priority_field.reference_name = "Microsoft.VSTS.Common.Priority"
+    
+    mock_process_client.get_all_work_item_type_fields.return_value = [mock_priority_field]
+    
+    # Setup mock for get_work_item_type_field
+    mock_field_detail = MagicMock(spec=WorkItemTypeField)
+    mock_field_detail.name = "Priority"
+    mock_field_detail.reference_name = "Microsoft.VSTS.Common.Priority"
+    mock_field_detail.type = "integer"
+    mock_field_detail.required = False
+    mock_field_detail.read_only = False
+    mock_field_detail.allowed_values = ["1", "2", "3", "4"]
+    
+    mock_process_client.get_work_item_type_field.return_value = mock_field_detail
+    mock_get_process_client.return_value = mock_process_client
+    
+    # Use display name for this test
+    field_name = "Priority"
+    
+    # Act
+    result = _get_work_item_type_field_impl("TestProject", "Bug", field_name, mock_wit_client)
+    
+    # Assert
+    # First verify it looked up all fields to find reference name
+    mock_process_client.get_all_work_item_type_fields.assert_called_once_with("process-id-123", "System.Bug")
+    
+    # Then verify it called get_work_item_type_field with the reference name
+    mock_process_client.get_work_item_type_field.assert_called_once_with(
+        "process-id-123", "System.Bug", "Microsoft.VSTS.Common.Priority"
+    )
+    
+    # Check result content
+    assert "Field: Priority" in result
+    assert "Reference Name: Microsoft.VSTS.Common.Priority" in result
+
+
+@patch("mcp_azure_devops.features.work_items.tools.types.get_core_client")
+@patch("mcp_azure_devops.features.work_items.tools.types.get_work_item_tracking_process_client")
+def test_get_work_item_type_field_impl_field_not_found(mock_get_process_client, mock_get_core_client):
+    """Test retrieving a field that doesn't exist."""
+    # Arrange
+    mock_wit_client = MagicMock()
+    mock_core_client = MagicMock()
+    mock_process_client = MagicMock()
+    
+    # Setup mock for get_work_item_type
+    mock_bug_type = MagicMock(spec=WorkItemType)
+    mock_bug_type.name = "Bug"
+    mock_bug_type.reference_name = "System.Bug"
+    mock_wit_client.get_work_item_type.return_value = mock_bug_type
+    
+    # Setup mock for get_project from core client
+    mock_project = MagicMock()
+    mock_project.capabilities = {
+        "processTemplate": {
+            "templateTypeId": "process-id-123"
+        }
+    }
+    mock_core_client.get_project.return_value = mock_project
+    mock_get_core_client.return_value = mock_core_client
+    
+    # Setup mock for get_all_work_item_type_fields - empty for lookup
+    mock_process_client.get_all_work_item_type_fields.return_value = []
+    mock_get_process_client.return_value = mock_process_client
+    
+    # Use a non-existent field name
+    field_name = "NonExistentField"
+    
+    # Act
+    result = _get_work_item_type_field_impl("TestProject", "Bug", field_name, mock_wit_client)
+    
+    # Assert
+    assert f"Field '{field_name}' not found for work item type 'Bug' in project 'TestProject'" in result

--- a/uv.lock
+++ b/uv.lock
@@ -264,7 +264,7 @@ cli = [
 
 [[package]]
 name = "mcp-azure-devops"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "azure-devops" },


### PR DESCRIPTION
Added tools needed for the AI assistant to figure out what process a project is using, what work item types are used in the process and what fields are used on those work item types. It also indicates required fields.

Updated the formatting of work items to be simpler (Now outputs all fields instead of specific fields).
Made create and update work items take in a dict with fields, so that they support all fields as well as custom fields.
Added in a prompt that can be used to create a basic starting conventions file, that can then be used in queries to prevent multiple similar calls to the AI model.