### PR TITLE
Fix naming of Create Conventions File to adhere to convention

### DIFF
--- a/src/mcp_azure_devops/utils/conventions_promp.py
+++ b/src/mcp_azure_devops/utils/conventions_promp.py
@@ -3,7 +3,7 @@ from mcp.server.fastmcp import FastMCP
 
 def register_prompt(mcp: FastMCP) -> None:
     
-    @mcp.prompt(name="Create Conventions File", 
+    @mcp.prompt(name="create_conventions_file", 
                 description="Create a starting conventions file Azure DevOps")
     def create_conventions_file() -> str:
         """


### PR DESCRIPTION
`mcp-use` forces the tools to be named according to this format: '^[a-zA-Z0-9_-]+$'. Otherwise, the following error is raised:

ERROR mcp_listener: Error during streaming: Error code: 400 - {'error': {'message': "Invalid 'tools[21].function.name': string does not match pattern. Expected a string that matches the pattern '^[a-zA-Z0-9_-]+$'.", 'type': 'invalid_request_error', 'param': 'tools[21].function.name', 'code': 'invalid_value'}}